### PR TITLE
update json encoding method.

### DIFF
--- a/lib/SiftRequest.php
+++ b/lib/SiftRequest.php
@@ -51,7 +51,7 @@ class SiftRequest {
         curl_setopt($ch, CURLOPT_URL, $curlUrl);
         curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
         if ($this->method == self::POST) {
-            $jsonString = $json->encode($this->properties);
+            $jsonString = $json->encodeUnsafe($this->properties);
             curl_setopt($ch, CURLOPT_POST, 1);
             curl_setopt($ch, CURLOPT_POSTFIELDS, $jsonString);
             curl_setopt($ch, CURLOPT_HTTPHEADER, array(


### PR DESCRIPTION
setting content-type header is unnecessary in Services_JSON::encode. and it causes errors about setting header after content when used in standalone script files.
