### PR TITLE
Fix constructor name for PHP 7 compatibility

### DIFF
--- a/lib/Services_JSON-1.0.3/JSON.php
+++ b/lib/Services_JSON-1.0.3/JSON.php
@@ -139,7 +139,7 @@ class Services_JSON
     *                                   strings or numbers, if you return an object, make sure it does
     *                                   not have a toJSON method, otherwise an error will occur.
     */
-    function Services_JSON($use = 0)
+    function __construct($use = 0)
     {
         $this->use = $use;
         $this->_mb_strlen            = function_exists('mb_strlen');
@@ -909,7 +909,7 @@ if (class_exists('PEAR_Error')) {
 
     class Services_JSON_Error extends PEAR_Error
     {
-        function Services_JSON_Error($message = 'unknown error', $code = null,
+        function __construct($message = 'unknown error', $code = null,
                                      $mode = null, $options = null, $userinfo = null)
         {
             parent::PEAR_Error($message, $code, $mode, $options, $userinfo);
@@ -923,7 +923,7 @@ if (class_exists('PEAR_Error')) {
      */
     class Services_JSON_Error
     {
-        function Services_JSON_Error($message = 'unknown error', $code = null,
+        function __construct($message = 'unknown error', $code = null,
                                      $mode = null, $options = null, $userinfo = null)
         {
 


### PR DESCRIPTION
This fixes the old style of constructor names.  Methods with the same name as their class will not be constructors in the latest versions of PHP (7+).