### PR TITLE
Adds support for v204 APIs, Entity Decisions API, and Workflow Status API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ php:
 install:
   - composer update
 script:
-  - phpunit --bootstrap vendor/autoload.php test/SiftClientTest
+  - phpunit --bootstrap vendor/autoload.php test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 install:
   - composer update

--- a/CHANGES.RST
+++ b/CHANGES.RST
@@ -1,3 +1,11 @@
+2.0.0 (2016-07-19)
+=================
+* adds support for v204 of Sift Science's APIs
+* adds Workflow Status API, User Decisions API, Order Decisions API
+* v204 APIs are now called by default -- this is an incompatible change
+  (use :version => 203 to call the previous API version)
+* uses Hash arg for optional params in Client methods -- incompatible change
+
 1.2.2 (2016-04-14)
 =================
 * Add return_action support to track method

--- a/README.md
+++ b/README.md
@@ -1,31 +1,47 @@
 # Sift Science PHP Bindings <a href="https://travis-ci.org/SiftScience/sift-php"><img src="https://travis-ci.org/SiftScience/sift-php.svg?branch=master">
 
+
 ## Installation
+
 ### With Composer
+
 1. Add siftscience/sift-php as a dependency in composer.json.
 
     ```
     "require": {
         ...
-        "siftscience/sift-php" : "1.*"
+        "siftscience/sift-php" : "2.*"
         ...
     }
     ```
 
 2. Run `composer update`.
+
 3. Now `SiftClient` will be autoloaded into your project.
 
 
     ```
     require 'vendor/autoload.php';
 
-    $sift = new SiftClient('my_api_key');
+    $sift = new SiftClient(array(
+        'api_key' => 'my_api_key',
+        'account_id' => 'my_account_id'
+    ));
+
+    // or
+
+    Sift::setApiKey('my_api_key');
+    Sift::setAccountId('my_account_id');
+    $sift = new SiftClient();
     ```
 
 ### Manually
+
 1. Download the latest release.
+
 2. Extract into a folder in your project root named "sift-php".
-2. Include `SiftClient` in your project like this:
+
+3. Include `SiftClient` in your project like this:
 
     ```
     require 'sift-php/lib/Services_JSON-1.0.3/JSON.php';
@@ -35,15 +51,19 @@
     require 'sift-php/lib/Sift.php';
 
 
-    $sift = new SiftClient('my_api_key');
+    $sift = new SiftClient(array(
+        'api_key' => 'my_api_key',
+        'account_id' => 'my_account_id'
+    ));
     ```
 
+
 ## Usage
+
 ### Track an event
 Here's an example that sends a `$transaction` event to sift.
-
 ```
-$sift = new SiftClient('my_api_key');
+$sift = new SiftClient(array('api_key' => 'my_api_key'));
 $response = $sift->track('$transaction', array(
     '$user_id' => '23056',
     '$user_email' => 'buyer@gmail.com',
@@ -57,43 +77,69 @@ $response = $sift->track('$transaction', array(
     'distance_traveled' => 5.26,
 ));
 ```
-### Label a user as good/bad
 
+### Label a user as good/bad
 ```
-$sift = new SiftClient('my_api_key');
+$sift = new SiftClient(array('api_key' => 'my_api_key'));
 $response = $sift->label('23056', array(
     '$is_bad' => true,
-    '$reasons' => array('$chargeback')
+    '$abuse_type' => 'promotion_abuse'
 ));
 ```
+
 ### Unlabel a user
+```
+$sift = new SiftClient(array('api_key' => 'my_api_key'));
+$response = $sift->unlabel('23056', array('abuse_type' => 'content_abuse'));
+```
 
-```
-$sift = new SiftClient('my_api_key');
-$response = $sift->unlabel('23056');
-```
 ### Get a user's score
-
 ```
-$sift = new SiftClient('my_api_key');
+$sift = new SiftClient(array('api_key' => 'my_api_key'));
 $response = $sift->score('23056');
-$response->body['score']; // => 0.030301357270181357
+$response->body['scores']['payment_abuse']['score']; // => 0.030301357270181357
 ```
 
+### Get the status of a workflow run
+```
+$sift = new SiftClient(array('api_key' => 'my_api_key', 'account_id' => 'my_account_id'));
+$response = $sift->getWorkflowStatus('my_run_id');
+$response->body['state']; // => "running"
+```
+
+### Get the latest decisions for a user
+```
+$sift = new SiftClient(array('api_key' => 'my_api_key', 'account_id' => 'my_account_id'));
+$response = $sift->getUserDecisions('example_user');
+$response->body['decisions']['account_abuse']['decision']['id']; // => "ban_user"
+```
+
+### Get the latest decisions for an order
+```
+$sift = new SiftClient(array('api_key' => 'my_api_key', 'account_id' => 'my_account_id'));
+$response = $sift->getOrderDecisions('example_order');
+$response->body['decisions']['payment_abuse']['decision']['id']; // => "ship_order"
+```
 
 ## Contributing
 Run the tests from the project root with [PHPUnit](http://phpunit.de) like this:
 
 ```
-phpunit --bootstrap vendor/autoload.php test/SiftClientTest
+phpunit --bootstrap vendor/autoload.php test
 ```
+
 
 ## Updating Packagist
 
-1. Update `composer.json` to reflect the new version, as well as any new requirements then merge changes into master.
+1. Update `composer.json` to reflect the new version, as well as any
+   new requirements then merge changes into master.
 
-2. Create a [new release](https://github.com/SiftScience/sift-php/releases) with the version number and use it as the description.
-[Packagist](https://packagist.org/packages/siftscience/sift-php) will automatically deploy a new package via the configured webhook.
+2. Create a [new release](https://github.com/SiftScience/sift-php/releases)
+    with the version number and use it as the description.
+    [Packagist](https://packagist.org/packages/siftscience/sift-php) will
+    automatically deploy a new package via the configured webhook.
+
 
 ## License
+
 MIT

--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,18 @@
     "keywords": ["sift", "sift science", "php", "fraud"],
     "homepage": "https://github.com/SiftScience/sift-php",
     "license": "MIT",
-    "version": "1.2.2",
+    "version": "2.0.0",
     "authors": [
         {
             "name": "Alex Lopatin"
         },
         {
             "name": "Yoav Schatzberg"
+        },
+        {
+            "name": "Jacob Burnim"
         }
+
     ],
     "support": {
         "email": "support@siftscience.com"

--- a/lib/Sift.php
+++ b/lib/Sift.php
@@ -7,10 +7,20 @@ abstract class Sift
 	 */
 	public static $api_key;
 
+        /**
+	 *	@var string the account ID to be used for requests if none is provided to the constructor.
+	 */
+	public static $account_id;
+
 	const VERSION = '1.2.0';
 
 	public static function setApiKey($api_key)
 	{
 		self::$api_key = $api_key;
+	}
+
+	public static function setAccountId($account_id)
+	{
+		self::$account_id = $account_id;
 	}
 }

--- a/lib/SiftResponse.php
+++ b/lib/SiftResponse.php
@@ -28,8 +28,13 @@ class SiftResponse {
         if (!in_array($this->httpStatusCode, array(204,304))) {
             $json = new Services_JSON(SERVICES_JSON_LOOSE_TYPE);
             $this->body = $json->decode($result);
-            $this->apiStatus = intval($this->body['status']);
-            $this->apiErrorMessage = $this->body['error_message'];
+            // NOTE: Responses from /v3 endpoints don't contain status or error_message.
+            if (array_key_exists('status', $this->body)) {
+                $this->apiStatus = intval($this->body['status']);
+            }
+            if (array_key_exists('error_message', $this->body)) {
+                $this->apiErrorMessage = $this->body['error_message'];
+            }
         }
     }
 
@@ -56,7 +61,8 @@ class SiftResponse {
             return 204 === $this->httpStatusCode;
         }
 
-        // Otherwise expect http status 200 and api status 0
-        return $this->apiStatus === 0 && 200 === $this->httpStatusCode;
+        // Otherwise expect http status 200 and api status 0.
+        // NOTE: $this->apiStatus will be null for all /v3 responses.
+        return ($this->apiStatus == 0) && (200 === $this->httpStatusCode);
     }
 }

--- a/test/SiftClient203Test.php
+++ b/test/SiftClient203Test.php
@@ -1,0 +1,160 @@
+<?php
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+class SiftClient203Test extends PHPUnit_Framework_TestCase {
+    private static $API_KEY = 'agreatsuccess';
+    private $client;
+    private $transaction_properties;
+    private $errors;
+
+
+    protected function setUp() {
+        $this->client = new SiftClient(array('api_key' => SiftClient203Test::$API_KEY));
+        $this->transaction_properties = array(
+            '$buyer_user_id' => '123456',
+            '$seller_user_id' => '56789',
+            '$amount' => 123456,
+            '$currency_code' => 'USD',
+            '$time' => time(),
+            '$transaction_id' => 'my_transaction_id',
+            '$billing_name' => 'Mike Snow',
+            '$billing_bin' => '411111',
+            '$billing_last4' => '1111',
+            '$billing_address1' => '123 Main St.',
+            '$billing_city' => 'San Francisco',
+            '$billing_region' => 'CA',
+            '$billing_country' => 'US',
+            '$billing_zip' => '94131',
+            '$user_email' => 'mike@example.com'
+        );
+        $this->label_properties = array(
+            '$reasons' => '[ "$fake" ]',
+            '$is_bad' => true,
+            '$description' => 'Listed a fake item'
+        );
+        $this->errors = array();
+        set_error_handler(array($this, "errorHandler"));
+    }
+ 
+    public function errorHandler($errno, $errstr, $errfile, $errline, $errcontext) {
+        $this->errors[] = compact("errno", "errstr", "errfile",
+            "errline", "errcontext");
+    }
+ 
+    public function assertError($errstr, $errno) {
+        foreach ($this->errors as $error) {
+            if ($error["errstr"] === $errstr
+                && $error["errno"] === $errno) {
+                return;
+            }
+        }
+        $this->fail("Error with level " . $errno .
+            " and message '" . $errstr . "' not found in ", 
+            var_export($this->errors, TRUE));
+    }
+
+    protected function tearDown() {
+        SiftRequest::clearMockResponse();
+    }
+
+    public function testSuccessfulTrackEvent() {
+        $mockUrl = 'https://api.siftscience.com/v203/events';
+        $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK"}', 200, null);
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::POST ,$mockResponse);
+        $response = $this->client->track('$transaction', $this->transaction_properties, array(
+            'version' => '203'
+        ));
+        $this->assertTrue($response->isOk());
+        $this->assertEquals($response->apiErrorMessage, 'OK');
+    }
+
+    public function testSuccessfulScoreFetch() {
+        $this->client = new SiftClient(array(
+            'api_key' => SiftClient203Test::$API_KEY, 'version' => '203'));
+        $mockUrl = 'https://api.siftscience.com/v203/score/12345?api_key=agreatsuccess';
+        $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
+                "user_id": "12345", "score": 0.55}', 200, null);
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
+        $response = $this->client->score('12345');
+        $this->assertTrue($response->isOk());
+        $this->assertEquals($response->apiErrorMessage, 'OK');
+        $this->assertEquals($response->body["score"], 0.55);
+    }
+
+    public function testSuccessfulSyncScoreFetch() {
+        $mockUrl = 'https://api.siftscience.com/v203/events?return_score=true';
+        $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
+                "score_response": {"user_id": "12345", "score": 0.55}}', 200, null);
+
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
+        $response = $this->client->track('$transaction', $this->transaction_properties, array(
+            'timeout' => 2,
+            'return_score' => true,
+            'version' => 203
+        ));
+        $this->assertTrue($response->isOk());
+        $this->assertEquals($response->apiErrorMessage, 'OK');
+        $this->assertEquals($response->body["score_response"]["score"], 0.55);
+    }
+
+    public function testSuccessfulLabelUser() {
+        $this->client = new SiftClient(array(
+            'api_key' => SiftClient203Test::$API_KEY, 'version' => '203'));
+        $mockUrl = 'https://api.siftscience.com/v203/users/54321/labels';
+        $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK"}', 200, null);
+
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
+        $response = $this->client->label("54321", $this->label_properties);
+        $this->assertTrue($response->isOk());
+        $this->assertEquals($response->apiErrorMessage, 'OK');
+    }
+
+    public function testSuccessfulUnlabelUser() {
+        $mockUrl = 'https://api.siftscience.com/v203/users/54321/labels?api_key=agreatsuccess';
+        $mockResponse = new SiftResponse('', 204, null);
+
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::DELETE, $mockResponse);
+        $response = $this->client->unlabel("54321", array('version' => '203'));
+        $this->assertTrue($response->isOk());
+    }
+
+    // Test all special characters for score API
+    public function testSuccessfulScoreFetchWithAllUserIdCharacters() {
+        $this->client = new SiftClient(array(
+            'api_key' => SiftClient203Test::$API_KEY, 'version' => '203'));
+        $mockUrl = 'https://api.siftscience.com/v203/score/12345' . urlencode('=.-_+@:&^%!$') . '?api_key=agreatsuccess';
+        $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
+                "user_id": "12345=.-_+@:&^%!$", "score": 0.55}', 200, null);
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
+        $response = $this->client->score('12345=.-_+@:&^%!$');
+        $this->assertTrue($response->isOk());
+        $this->assertEquals($response->apiErrorMessage, 'OK');
+        $this->assertEquals($response->body["score"], 0.55);
+    }
+
+    // Test all special characters for Label API
+    public function testSuccessfulLabelWithAllUserIdCharacters() {
+        $mockUrl = 'https://api.siftscience.com/v203/users/54321' . urlencode('=.-_+@:&^%!$') . '/labels';
+        $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK"}', 200, null);
+
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
+        $response = $this->client->label("54321=.-_+@:&^%!$", $this->label_properties, array(
+            'version' => '203'
+        ));
+        $this->assertTrue($response->isOk());
+        $this->assertEquals($response->apiErrorMessage, 'OK');
+    }
+
+    // Test all special characters for Unlabel API
+    public function testSuccessfulUnlabelWithAllUserIdCharacters() {
+        $this->client = new SiftClient(array(
+            'api_key' => SiftClient203Test::$API_KEY, 'version' => '203'));
+        $mockUrl = 'https://api.siftscience.com/v203/users/54321' . urlencode('=.-_+@:&^%!$') . '/labels?api_key=agreatsuccess';
+        $mockResponse = new SiftResponse('', 204, null);
+
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::DELETE, $mockResponse);
+        $response = $this->client->unlabel("54321=.-_+@:&^%!$");
+        $this->assertTrue($response->isOk());
+    }
+
+}


### PR DESCRIPTION
This PR:

 - Adds support for v204 of Sift Science's API.

 - Adds support for the Workflow Status API, User Decisions API, and Order Decisions API.

 - Version 204 of the Sift Science API is now called by default -- this is an incompatible change, as some fields are no longer returned in the v204 API (unless they are explicitly requested).

 - Cleans up all Client methods (and the constructor) using an Array argument for optional parameters. This is an incompatible change.

 - Bumps version to 2.0.0.0.

 - Tests under php7 in TravisCI.

@nickhurlburt and @yschatzberg -- could you please review this PR?
cc @aaronTufts 