### PR TITLE
Fix Warnings when response body is empty

### DIFF
--- a/lib/SiftResponse.php
+++ b/lib/SiftResponse.php
@@ -28,12 +28,15 @@ class SiftResponse {
         if (!in_array($this->httpStatusCode, array(204,304))) {
             $json = new Services_JSON(SERVICES_JSON_LOOSE_TYPE);
             $this->body = $json->decode($result);
-            // NOTE: Responses from /v3 endpoints don't contain status or error_message.
-            if (array_key_exists('status', $this->body)) {
-                $this->apiStatus = intval($this->body['status']);
-            }
-            if (array_key_exists('error_message', $this->body)) {
-                $this->apiErrorMessage = $this->body['error_message'];
+            
+            if (isset($this->body)) {
+                // NOTE: Responses from /v3 endpoints don't contain status or error_message.
+                if (array_key_exists('status', $this->body)) {
+                    $this->apiStatus = intval($this->body['status']);
+                }
+                if (array_key_exists('error_message', $this->body)) {
+                    $this->apiErrorMessage = $this->body['error_message'];
+                } 
             }
         }
     }


### PR DESCRIPTION
We need to check if the body is set, otherwise when the body of the response is empty the function array_key_exists in lines 34 and 37 give the following warning:

E_WARNING: array_key_exists() expects parameter 2 to be array, null given
