### PR TITLE
Fixed use of non-existing variables

### DIFF
--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -213,7 +213,7 @@ class SiftClient {
 
         try {
             $request = new SiftRequest(self::userLabelApiUrl($userId, $opts['version']),
-                SiftRequest::DELETE, $timeout, $version, array('params' => $params));
+                SiftRequest::DELETE, $opts['timeout'], $opts['version'], array('params' => $params));
             return $request->send();
         } catch (Exception $e) {
             return null;

--- a/test/SiftClient203Test.php
+++ b/test/SiftClient203Test.php
@@ -5,8 +5,6 @@ class SiftClient203Test extends PHPUnit_Framework_TestCase {
     private static $API_KEY = 'agreatsuccess';
     private $client;
     private $transaction_properties;
-    private $errors;
-
 
     protected function setUp() {
         $this->client = new SiftClient(array('api_key' => SiftClient203Test::$API_KEY));
@@ -32,25 +30,6 @@ class SiftClient203Test extends PHPUnit_Framework_TestCase {
             '$is_bad' => true,
             '$description' => 'Listed a fake item'
         );
-        $this->errors = array();
-        set_error_handler(array($this, "errorHandler"));
-    }
- 
-    public function errorHandler($errno, $errstr, $errfile, $errline, $errcontext) {
-        $this->errors[] = compact("errno", "errstr", "errfile",
-            "errline", "errcontext");
-    }
- 
-    public function assertError($errstr, $errno) {
-        foreach ($this->errors as $error) {
-            if ($error["errstr"] === $errstr
-                && $error["errno"] === $errno) {
-                return;
-            }
-        }
-        $this->fail("Error with level " . $errno .
-            " and message '" . $errstr . "' not found in ", 
-            var_export($this->errors, TRUE));
     }
 
     protected function tearDown() {

--- a/test/SiftClientTest.php
+++ b/test/SiftClientTest.php
@@ -6,8 +6,6 @@ class SiftClientTest extends PHPUnit_Framework_TestCase {
     private static $ACCOUNT_ID = '90201c25e39320c45b3da37b';
     private $client;
     private $transaction_properties;
-    private $errors;
-
 
     protected function setUp() {
         $this->client = new SiftClient(array(
@@ -36,27 +34,8 @@ class SiftClientTest extends PHPUnit_Framework_TestCase {
             '$abuse_type' => 'content_abuse',
             '$description' => 'Listed a fake item'
         );
-        $this->errors = array();
-        set_error_handler(array($this, "errorHandler"));
     }
  
-    public function errorHandler($errno, $errstr, $errfile, $errline, $errcontext) {
-        $this->errors[] = compact("errno", "errstr", "errfile",
-            "errline", "errcontext");
-    }
- 
-    public function assertError($errstr, $errno) {
-        foreach ($this->errors as $error) {
-            if ($error["errstr"] === $errstr
-                && $error["errno"] === $errno) {
-                return;
-            }
-        }
-        $this->fail("Error with level " . $errno .
-            " and message '" . $errstr . "' not found in ", 
-            var_export($this->errors, TRUE));
-    }
-
     protected function tearDown() {
         SiftRequest::clearMockResponse();
     }


### PR DESCRIPTION
Hi, I'm using this library and found a bug.

`unlabel()` function referred a non-existing variable.
https://github.com/SiftScience/sift-php/blob/master/lib/SiftClient.php#L216

`$timeout` and `$version` variables should be `$opts['timeout']` and `$opts['version']`.