### PR TITLE
Make unlabel method use opts instead of undefined variables

### DIFF
--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -213,7 +213,7 @@ class SiftClient {
 
         try {
             $request = new SiftRequest(self::userLabelApiUrl($userId, $opts['version']),
-                SiftRequest::DELETE, $timeout, $version, array('params' => $params));
+                SiftRequest::DELETE, $opts['timeout'], $opts['version'], array('params' => $params));
             return $request->send();
         } catch (Exception $e) {
             return null;


### PR DESCRIPTION
When you attempt to use the `unlabel` method as currently written in master, `timeout` and `version` are both undefined variables. They're intended to reference the `opts` array, but they don't.

My change fixes this, which should fix the unlabel method.

It's unclear why unit tests don't pick this up. It seems as though using `setMockResponse` is short-circuiting the constructor somehow, but it isn't clear how.