### PR TITLE
Fix incorrect phpDoc variable description on label()

### DIFF
--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -160,7 +160,7 @@ class SiftClient {
      *
      * @param string $userId  The ID of a user.  This parameter is required.
      *
-     * @param $properties An array of name-value pairs that specify the label attributes. This
+     * @param array $properties An array of name-value pairs that specify the label attributes. This
      *     parameter is required.
      *
      * @param array $opts  Array of optional parameters for this request:

--- a/test/SiftClientTest.php
+++ b/test/SiftClientTest.php
@@ -4,8 +4,13 @@ require_once dirname(__DIR__) . '/vendor/autoload.php';
 class SiftClientTest extends PHPUnit_Framework_TestCase {
     private static $API_KEY = 'agreatsuccess';
     private static $ACCOUNT_ID = '90201c25e39320c45b3da37b';
+
+    /*
+     * @var SiftClient Ėclient
+     */
     private $client;
     private $transaction_properties;
+    private $label_properties = [];
 
     protected function setUp() {
         $this->client = new SiftClient(array(


### PR DESCRIPTION
Fix incorrect phpDoc variable description on label()

Fixes warning of type in PHPStorm IDE.