### PR TITLE
Fix incorrect phpDoc variable type for label() of SiftClient class

### DIFF
--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -160,7 +160,7 @@ class SiftClient {
      *
      * @param string $userId  The ID of a user.  This parameter is required.
      *
-     * @param $properties An array of name-value pairs that specify the label attributes. This
+     * @param array $properties An array of name-value pairs that specify the label attributes. This
      *     parameter is required.
      *
      * @param array $opts  Array of optional parameters for this request:

--- a/test/SiftClientTest.php
+++ b/test/SiftClientTest.php
@@ -6,6 +6,7 @@ class SiftClientTest extends PHPUnit_Framework_TestCase {
     private static $ACCOUNT_ID = '90201c25e39320c45b3da37b';
     private $client;
     private $transaction_properties;
+    private $label_properties = array();
 
     protected function setUp() {
         $this->client = new SiftClient(array(


### PR DESCRIPTION
Fix incorrect phpDoc variable type for label() of SiftClient class

I closed previous PR https://github.com/SiftScience/sift-php/pull/43  because made mistake by creating pull request from fork's master branch
