### PR TITLE
(For Jacob, Gary) Adds methods to use new decisions APIs

### DIFF
--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -364,6 +364,84 @@ class SiftClient {
       }
     }
 
+    public function applyDecisionToUser($opts = array()) {
+      $this->mergeArguments($opts, array(
+        'account_id' => $this->account_id,
+        'timeout' => $this->timeout,
+        'decision_id' => null,
+        'source' => null,
+        'analyst' => null,
+        'user_id' => null,
+        'description' => null,
+        'time' => null
+      ));
+
+      $url = (self::API3_ENDPOINT .
+        '/v3/accounts/' . $opts['account_id'] .
+        '/users/'. $opts['user_id'] .
+        '/decisions');
+
+      return $this->applyDecision($url, $opts);
+    }
+
+    public function applyDecisionToOrder($opts = array()) {
+      $this->mergeArguments($opts, array(
+        'account_id' => $this->account_id,
+        'timeout' => $this->timeout,
+        'decision_id' => null,
+        'source' => null,
+        'analyst' => null,
+        'user_id' => null,
+        'order_id' => null,
+        'description' => null,
+        'time' => null
+      ));
+
+      $this->validateArgument($opts['order_id'], 'order_id', 'string');
+
+      $url = (self::API3_ENDPOINT .
+        '/v3/accounts/' . $opts['account_id'] .
+        '/users/' . $opts['user_id'] .
+        '/orders/' . $opts['order_id'] .
+        '/decisions');
+
+      return $this->applyDecision($url, $opts);
+    }
+
+    /**
+     *
+     */
+    private function applyDecision($url, $opts = array()) {
+      $this->validateArgument($opts['decision_id'], 'decision_id', 'string');
+      $this->validateArgument($opts['user_id'], 'user_id', 'string');
+      $this->validateArgument($opts['source'], 'source', 'string');
+
+      $body = array(
+        'decision_id' => $opts['decision_id'],
+        'source' => $opts['source']
+      );
+
+      if ($opts['analyst']) $body['analyst'] = $opts['analyst'];
+      if ($opts['description']) $body['description'] = $opts['description'];
+
+      try {
+        $request = new SiftRequest(
+          $url,
+          SiftRequest::POST,
+          $opts['timeout'],
+          self::API3_VERSION,
+          array(
+            'auth' => $this->api_key . ':',
+            'body' => $body
+          )
+        );
+
+        return $request->send();
+      } catch (Exception $e) {
+        return null;
+      }
+    }
+
 
     /**
      * Merges a function's default parameter values into an array of arguments.

--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -311,6 +311,33 @@ class SiftClient {
     }
 
 
+    public function getDecisions($opts = array()) {
+      $this->mergeArguments($opts, array(
+        'account_id' => $this->account_id,
+        'timeout' => $this->timeout
+      ));
+
+      $url = (self::API3_ENDPOINT . '/v3/accounts/' . $opts['account_id']
+              . '/decisions');
+
+      $params = array();
+      if ($opts['abuse_types']) $params['abuse_types'] = implode(',', $opts['abuse_types']);
+      if ($opts['entity_type']) $params['entity_type'] = $opts['entity_type'];
+      if ($opts['limit']) $params['limit'] = $opts['limit'];
+      if ($opts['from']) $params['from'] = $opts['from'];
+
+      try {
+        $request = new SiftRequest($url, SiftRequest::GET, $opts['timeout'],
+          self::API3_VERSION,
+          array('auth' => $this->api_key . ':'));
+
+        return $request->send();
+      } catch (Exception $e) {
+        return null;
+      }
+    }
+
+
     /**
      * Merges a function's default parameter values into an array of arguments.
      *

--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -284,7 +284,7 @@ class SiftClient {
     /**
      * Gets the latest decision for a user for each abuse type.
      *
-     * @param string $user_id  The ID of a user.
+     * @param string $order_id  The ID of an order.
      *
      * @param array $opts  Array of optional parameters for this request:
      *     - string 'account_id': by default, this client's account ID is used.
@@ -310,7 +310,24 @@ class SiftClient {
         }
     }
 
-
+    /**
+     * Gets a list of configured decisions.
+     *
+     * @param array &$opts  The array of arguments passed to a function.
+     *
+     * @param array $opts  Array of optional parameters for this request:
+     *     - string 'account_id': by default, this client's account ID is used.
+     *     - int 'timeout': By default, this client's timeout is used.
+     *     - array 'abuse_types': filters decisions which can be apply to
+     *       listed abuse types
+     *     - string 'entity_type': filters on decisions which can be applied to
+     *       a specified entity_type
+     *     - string 'next_ref': url that will fetch the next page of decisions
+     *     - int 'limit': sets the max number of decisions returned
+     *     - int 'from': will return the next decision from the index given up
+     *       to the limit.
+     *
+     */
     public function getDecisions($opts = array()) {
       $this->mergeArguments($opts, array(
         'account_id' => $this->account_id,

--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -341,8 +341,7 @@ class SiftClient {
         if ($opts['next_ref']) {
             $url = $opts['next_ref'];
         } else {
-            $url = (self::API3_ENDPOINT . '/v3/accounts/' . $opts['account_id']
-                    . '/decisions');
+            $url = (self::API3_ENDPOINT . '/v3/accounts/' . $opts['account_id'] . '/decisions');
 
             if ($opts['abuse_types']) $params['abuse_types'] = implode(',', $opts['abuse_types']);
             if ($opts['entity_type']) $params['entity_type'] = $opts['entity_type'];

--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -352,8 +352,8 @@ class SiftClient {
 
         try {
             $request = new SiftRequest($url, SiftRequest::GET, $opts['timeout'],
-              self::API3_VERSION,
-              array('auth' => $this->api_key . ':'));
+                self::API3_VERSION,
+                array('auth' => $this->api_key . ':'));
 
             return $request->send();
         } catch (Exception $e) {

--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -316,7 +316,7 @@ class SiftClient {
      * @param array $opts  Array of optional parameters for this request:
      *     - string 'account_id': by default, this client's account ID is used.
      *     - int 'timeout': By default, this client's timeout is used.
-     *     - array 'abuse_types': filters decisions which can be apply to
+     *     - array 'abuse_types': filters decisions which can be appiled to
      *       listed abuse types
      *     - string 'entity_type': filters on decisions which can be applied to
      *       a specified entity_type
@@ -324,156 +324,154 @@ class SiftClient {
      *     - int 'limit': sets the max number of decisions returned
      *     - int 'from': will return the next decision from the index given up
      *       to the limit.
-     *
      */
     public function getDecisions($opts = array()) {
-      $this->mergeArguments($opts, array(
-        'account_id' => $this->account_id,
-        'timeout' => $this->timeout,
-        'abuse_types' => null,
-        'entity_type' => null,
-        'next_ref' => null,
-        'limit' => null,
-        'from' => null
-      ));
+        $this->mergeArguments($opts, array(
+            'account_id' => $this->account_id,
+            'timeout' => $this->timeout,
+            'abuse_types' => null,
+            'entity_type' => null,
+            'next_ref' => null,
+            'limit' => null,
+            'from' => null
+        ));
 
-      $params = array();
+        $params = array();
 
-      if ($opts['next_ref']) {
-        $url = $opts['next_ref'];
-      } else {
-        $url = (self::API3_ENDPOINT . '/v3/accounts/' . $opts['account_id']
-                . '/decisions');
+        if ($opts['next_ref']) {
+            $url = $opts['next_ref'];
+        } else {
+            $url = (self::API3_ENDPOINT . '/v3/accounts/' . $opts['account_id']
+                    . '/decisions');
 
-        if ($opts['abuse_types']) $params['abuse_types'] = implode(',', $opts['abuse_types']);
-        if ($opts['entity_type']) $params['entity_type'] = $opts['entity_type'];
-        if ($opts['limit']) $params['limit'] = $opts['limit'];
-        if ($opts['from']) $params['from'] = $opts['from'];
-      }
+            if ($opts['abuse_types']) $params['abuse_types'] = implode(',', $opts['abuse_types']);
+            if ($opts['entity_type']) $params['entity_type'] = $opts['entity_type'];
+            if ($opts['limit']) $params['limit'] = $opts['limit'];
+            if ($opts['from']) $params['from'] = $opts['from'];
+        }
 
-      try {
-        $request = new SiftRequest($url, SiftRequest::GET, $opts['timeout'],
-          self::API3_VERSION,
-          array('auth' => $this->api_key . ':'));
+        try {
+            $request = new SiftRequest($url, SiftRequest::GET, $opts['timeout'],
+              self::API3_VERSION,
+              array('auth' => $this->api_key . ':'));
 
-        return $request->send();
-      } catch (Exception $e) {
-        return null;
-      }
+            return $request->send();
+        } catch (Exception $e) {
+            return null;
+        }
     }
 
     /**
      * Apply a decision to a user. Builds url to apply decision to user and
      * delegates to applyDecision
      *
+     * @param string $user_id the id of the user that will get this decision
+     * @param string $decision_id The decision that will be applied to a user
+     * @param string $source the source of the decision, i.e. MANUAL_REVIEW,
+     *     AUTOMATED_RULE, CHARGEBACK
      * @param array $opts  Array of optional parameters for this request:
      *     - string 'account_id': by default, this client's account ID is used.
      *     - int 'timeout': By default, this client's timeout is used.
-     *     - string 'decision_id': The decision that will be applied to a user
-     *     - string 'source': the source of the decision, i.e. MANUAL_REVIEW,
-     *     AUTOMATED_RULE, CHARGEBACK
      *     - string 'analyst': when the source is MANUAL_REVIEW, an analyst
      *     identifier must be passed.
-     *     - string 'user_id': the id of the user that will get this decision
      *     - string 'description': free form text adding context to why this
      *     decision is being applied.
      *     - int 'time': Timestamp of when a decision was applied, mainly used
      *     for backfilling
-     *
      */
-    public function applyDecisionToUser($opts = array()) {
-      $this->mergeArguments($opts, array(
-        'account_id' => $this->account_id,
-        'timeout' => $this->timeout,
-        'decision_id' => null,
-        'source' => null,
-        'analyst' => null,
-        'user_id' => null,
-        'description' => null,
-        'time' => null
-      ));
+    public function applyDecisionToUser($user_id, $decision_id, $source, $opts = array()) {
+        $this->mergeArguments($opts, array(
+            'account_id' => $this->account_id,
+            'timeout' => $this->timeout,
+            'decision_id' => $decision_id,
+            'source' => $source,
+            'analyst' => null,
+            'description' => null,
+            'time' => null
+        ));
 
-      $url = (self::API3_ENDPOINT .
-        '/v3/accounts/' . $opts['account_id'] .
-        '/users/'. $opts['user_id'] .
-        '/decisions');
+        $this->validateArgument($user_id, 'user_id', 'string');
 
-      return $this->applyDecision($url, $opts);
+        $url = (self::API3_ENDPOINT .
+            '/v3/accounts/' . $opts['account_id'] .
+            '/users/'. $user_id .
+            '/decisions');
+
+        return $this->applyDecision($url, $opts);
     }
 
     /**
      * Apply a decision to a user. Validates presence of order_id and builds
      * the url to apply a decision to an order and delegates to applyDecision.
      *
+     * @param string $user_id the id of order's user id
+     * @param string $order_id the id of the order which the decision will be
+     * applied
+     * @param string $decision_id The decision that will be applied to a user
+     * @param string $source the source of the decision, i.e. MANUAL_REVIEW,
      * @param array $opts  Array of optional parameters for this request:
+     *     AUTOMATED_RULE, CHARGEBACK
      *     - string 'account_id': by default, this client's account ID is used.
      *     - int 'timeout': By default, this client's timeout is used.
-     *     - string 'decision_id': The decision that will be applied to a user
-     *     - string 'source': the source of the decision, i.e. MANUAL_REVIEW,
-     *     AUTOMATED_RULE, CHARGEBACK
      *     - string 'analyst': when the source is MANUAL_REVIEW, an analyst
      *     identifier must be passed.
-     *     - string 'user_id': the id of the user that will get this decision
      *     - string 'description': free form text adding context to why this
      *     decision is being applied.
      *     - int 'time': Timestamp of when a decision was applied, mainly used
      *     for backfilling
-     *
      */
-    public function applyDecisionToOrder($opts = array()) {
-      $this->mergeArguments($opts, array(
-        'account_id' => $this->account_id,
-        'timeout' => $this->timeout,
-        'decision_id' => null,
-        'source' => null,
-        'analyst' => null,
-        'user_id' => null,
-        'order_id' => null,
-        'description' => null,
-        'time' => null
-      ));
+    public function applyDecisionToOrder($user_id, $order_id, $decision_id, $source, $opts = array()) {
+        $this->mergeArguments($opts, array(
+            'account_id' => $this->account_id,
+            'timeout' => $this->timeout,
+            'decision_id' => $decision_id,
+            'source' => $source,
+            'analyst' => null,
+            'description' => null,
+            'time' => null
+        ));
 
-      $this->validateArgument($opts['order_id'], 'order_id', 'string');
+        $this->validateArgument($order_id, 'order_id', 'string');
+        $this->validateArgument($user_id, 'user_id', 'string');
 
-      $url = (self::API3_ENDPOINT .
-        '/v3/accounts/' . $opts['account_id'] .
-        '/users/' . $opts['user_id'] .
-        '/orders/' . $opts['order_id'] .
-        '/decisions');
+        $url = (self::API3_ENDPOINT .
+            '/v3/accounts/' . $opts['account_id'] .
+            '/users/' . $user_id .
+            '/orders/' . $order_id .
+            '/decisions');
 
-      return $this->applyDecision($url, $opts);
+        return $this->applyDecision($url, $opts);
     }
 
     private function applyDecision($url, $opts = array()) {
-      $this->validateArgument($opts['decision_id'], 'decision_id', 'string');
-      $this->validateArgument($opts['user_id'], 'user_id', 'string');
-      $this->validateArgument($opts['source'], 'source', 'string');
+        $this->validateArgument($opts['decision_id'], 'decision_id', 'string');
+        $this->validateArgument($opts['source'], 'source', 'string');
 
-      $body = array(
-        'decision_id' => $opts['decision_id'],
-        'source' => $opts['source']
-      );
-
-      if ($opts['analyst']) $body['analyst'] = $opts['analyst'];
-      if ($opts['description']) $body['description'] = $opts['description'];
-      if ($opts['time']) $body['time'] = $opts['time'];
-
-      try {
-        $request = new SiftRequest(
-          $url,
-          SiftRequest::POST,
-          $opts['timeout'],
-          self::API3_VERSION,
-          array(
-            'auth' => $this->api_key . ':',
-            'body' => $body
-          )
+        $body = array(
+            'decision_id' => $opts['decision_id'],
+            'source' => $opts['source']
         );
 
-        return $request->send();
-      } catch (Exception $e) {
-        return null;
-      }
+        if ($opts['analyst']) $body['analyst'] = $opts['analyst'];
+        if ($opts['description']) $body['description'] = $opts['description'];
+        if ($opts['time']) $body['time'] = $opts['time'];
+
+        try {
+            $request = new SiftRequest(
+                $url,
+                SiftRequest::POST,
+                $opts['timeout'],
+                self::API3_VERSION,
+                array(
+                    'auth' => $this->api_key . ':',
+                    'body' => $body
+                )
+            );
+
+            return $request->send();
+        } catch (Exception $e) {
+            return null;
+        }
     }
 
 

--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -314,17 +314,27 @@ class SiftClient {
     public function getDecisions($opts = array()) {
       $this->mergeArguments($opts, array(
         'account_id' => $this->account_id,
-        'timeout' => $this->timeout
+        'timeout' => $this->timeout,
+        'abuse_types' => null,
+        'entity_type' => null,
+        'next_ref' => null,
+        'limit' => null,
+        'from' => null
       ));
 
-      $url = (self::API3_ENDPOINT . '/v3/accounts/' . $opts['account_id']
-              . '/decisions');
-
       $params = array();
-      if ($opts['abuse_types']) $params['abuse_types'] = implode(',', $opts['abuse_types']);
-      if ($opts['entity_type']) $params['entity_type'] = $opts['entity_type'];
-      if ($opts['limit']) $params['limit'] = $opts['limit'];
-      if ($opts['from']) $params['from'] = $opts['from'];
+
+      if ($opts['next_ref']) {
+        $url = $opts['next_ref'];
+      } else {
+        $url = (self::API3_ENDPOINT . '/v3/accounts/' . $opts['account_id']
+                . '/decisions');
+
+        if ($opts['abuse_types']) $params['abuse_types'] = implode(',', $opts['abuse_types']);
+        if ($opts['entity_type']) $params['entity_type'] = $opts['entity_type'];
+        if ($opts['limit']) $params['limit'] = $opts['limit'];
+        if ($opts['from']) $params['from'] = $opts['from'];
+      }
 
       try {
         $request = new SiftRequest($url, SiftRequest::GET, $opts['timeout'],

--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -313,8 +313,6 @@ class SiftClient {
     /**
      * Gets a list of configured decisions.
      *
-     * @param array &$opts  The array of arguments passed to a function.
-     *
      * @param array $opts  Array of optional parameters for this request:
      *     - string 'account_id': by default, this client's account ID is used.
      *     - int 'timeout': By default, this client's timeout is used.
@@ -364,6 +362,25 @@ class SiftClient {
       }
     }
 
+    /**
+     * Apply a decision to a user. Builds url to apply decision to user and
+     * delegates to applyDecision
+     *
+     * @param array $opts  Array of optional parameters for this request:
+     *     - string 'account_id': by default, this client's account ID is used.
+     *     - int 'timeout': By default, this client's timeout is used.
+     *     - string 'decision_id': The decision that will be applied to a user
+     *     - string 'source': the source of the decision, i.e. MANUAL_REVIEW,
+     *     AUTOMATED_RULE, CHARGEBACK
+     *     - string 'analyst': when the source is MANUAL_REVIEW, an analyst
+     *     identifier must be passed.
+     *     - string 'user_id': the id of the user that will get this decision
+     *     - string 'description': free form text adding context to why this
+     *     decision is being applied.
+     *     - int 'time': Timestamp of when a decision was applied, mainly used
+     *     for backfilling
+     *
+     */
     public function applyDecisionToUser($opts = array()) {
       $this->mergeArguments($opts, array(
         'account_id' => $this->account_id,
@@ -384,6 +401,25 @@ class SiftClient {
       return $this->applyDecision($url, $opts);
     }
 
+    /**
+     * Apply a decision to a user. Validates presence of order_id and builds
+     * the url to apply a decision to an order and delegates to applyDecision.
+     *
+     * @param array $opts  Array of optional parameters for this request:
+     *     - string 'account_id': by default, this client's account ID is used.
+     *     - int 'timeout': By default, this client's timeout is used.
+     *     - string 'decision_id': The decision that will be applied to a user
+     *     - string 'source': the source of the decision, i.e. MANUAL_REVIEW,
+     *     AUTOMATED_RULE, CHARGEBACK
+     *     - string 'analyst': when the source is MANUAL_REVIEW, an analyst
+     *     identifier must be passed.
+     *     - string 'user_id': the id of the user that will get this decision
+     *     - string 'description': free form text adding context to why this
+     *     decision is being applied.
+     *     - int 'time': Timestamp of when a decision was applied, mainly used
+     *     for backfilling
+     *
+     */
     public function applyDecisionToOrder($opts = array()) {
       $this->mergeArguments($opts, array(
         'account_id' => $this->account_id,
@@ -408,9 +444,6 @@ class SiftClient {
       return $this->applyDecision($url, $opts);
     }
 
-    /**
-     *
-     */
     private function applyDecision($url, $opts = array()) {
       $this->validateArgument($opts['decision_id'], 'decision_id', 'string');
       $this->validateArgument($opts['user_id'], 'user_id', 'string');
@@ -423,6 +456,7 @@ class SiftClient {
 
       if ($opts['analyst']) $body['analyst'] = $opts['analyst'];
       if ($opts['description']) $body['description'] = $opts['description'];
+      if ($opts['time']) $body['time'] = $opts['time'];
 
       try {
         $request = new SiftRequest(

--- a/lib/SiftRequest.php
+++ b/lib/SiftRequest.php
@@ -85,10 +85,10 @@ class SiftRequest {
                 $json = new Services_JSON();
                 $jsonString = $json->encodeUnsafe($this->body);
             }
+
             curl_setopt($ch, CURLOPT_POST, 1);
             curl_setopt($ch, CURLOPT_POSTFIELDS, $jsonString);
-            $headers += array(
-                'Content-Type: application/json',
+            array_push($headers, 'Content-Type: application/json',
                 'Content-Length: ' . strlen($jsonString)
             );
 

--- a/test/SiftClientTest.php
+++ b/test/SiftClientTest.php
@@ -35,7 +35,7 @@ class SiftClientTest extends PHPUnit_Framework_TestCase {
             '$description' => 'Listed a fake item'
         );
     }
- 
+
     protected function tearDown() {
         SiftRequest::clearMockResponse();
     }
@@ -308,6 +308,50 @@ class SiftClientTest extends PHPUnit_Framework_TestCase {
         SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
 
         $response = $this->client->getOrderDecisions('example_order', array('timeout' => 4));
+        $this->assertTrue($response->isOk());
+    }
+
+    public function testGetDecisionList() {
+        $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/decisions';
+        $mockResponse = new SiftResponse('{"data": [{' .
+          '"id": "block_user_payment_abuse", "name": "Block user",' .
+          '"description": "cancel and refund all of the user\'s' .
+          ' pending order.", "entity_type": "user,"' .
+          '"abuse_type": "payment_abuse",' .
+          '"category": "block",' .
+          '"webhook_url": "http://webhook.example.com",' .
+          '"created_at": 1468005577348,' .
+          '"created_by": "admin@example.com",' .
+          '"updated_at": 1469229177756,' .
+          '"updated_by": "billy@exmaple.com"' .
+          '}]}', 200, null);
+
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
+
+        $response = $this->client->getDecisions();
+        $this->assertTrue($response->isOk());
+    }
+
+    public function testGetDecisionListNextRef() {
+        $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/decisions?from=10&limit=5';
+        $mockResponse = new SiftResponse('{"data": [{' .
+          '"id": "block_user_payment_abuse", "name": "Block user",' .
+          '"description": "cancel and refund all of the user\'s' .
+          ' pending order.", "entity_type": "user,"' .
+          '"abuse_type": "payment_abuse",' .
+          '"category": "block",' .
+          '"webhook_url": "http://webhook.example.com",' .
+          '"created_at": 1468005577348,' .
+          '"created_by": "admin@example.com",' .
+          '"updated_at": 1469229177756,' .
+          '"updated_by": "billy@exmaple.com"' .
+          '}]}', 200, null);
+
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
+
+        $response = $this->client->getDecisions(array(
+          'next_ref' => $mockUrl
+        ));
         $this->assertTrue($response->isOk());
     }
 }

--- a/test/SiftClientTest.php
+++ b/test/SiftClientTest.php
@@ -354,4 +354,55 @@ class SiftClientTest extends PHPUnit_Framework_TestCase {
         ));
         $this->assertTrue($response->isOk());
     }
+
+    public function testApplyDecisionOnUser() {
+        $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/users/some_user/decisions';
+        $mockResponse = new SiftResponse('{' .
+            '"entity": {' .
+                '"id" : "some_user"' .
+                '"type" : "USER"' .
+            '},' .
+            '"decision": {' .
+                '"id": "user_looks_ok_payment_abuse"' .
+            '},' .
+            '"time": "1461963439151"' .
+            '}' .
+        '}', 200, null);
+
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
+
+        $response = $this->client->applyDecisionToUser(array(
+          'user_id' => 'some_user',
+          'decision_id' => 'user_looks_ok_payment_abuse',
+          'source' => 'MANUAL_REVIEW',
+          'analyst' => 'analyst@example.com',
+        ));
+        $this->assertTrue($response->isOk());
+    }
+
+    public function testApplyDecisionOnOrder() {
+        $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/users/some_user/orders/ORDER_1234/decisions';
+        $mockResponse = new SiftResponse('{' .
+            '"entity": {' .
+                '"id" : "ORDER_1234"' .
+                '"type" : "ORDER"' .
+            '},' .
+            '"decision": {' .
+                '"id": "order_looks_ok_payment_abuse"' .
+            '},' .
+            '"time": "1461963439151"' .
+            '}' .
+        '}', 200, null);
+
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
+
+        $response = $this->client->applyDecisionToOrder(array(
+          'user_id' => 'some_user',
+          'order_id' => 'ORDER_1234',
+          'decision_id' => 'order_looks_ok_payment_abuse',
+          'source' => 'MANUAL_REVIEW',
+          'analyst' => 'analyst@example.com',
+        ));
+        $this->assertTrue($response->isOk());
+    }
 }

--- a/test/SiftClientTest.php
+++ b/test/SiftClientTest.php
@@ -371,12 +371,11 @@ class SiftClientTest extends PHPUnit_Framework_TestCase {
 
         SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
 
-        $response = $this->client->applyDecisionToUser(array(
-          'user_id' => 'some_user',
-          'decision_id' => 'user_looks_ok_payment_abuse',
-          'source' => 'MANUAL_REVIEW',
-          'analyst' => 'analyst@example.com',
-        ));
+        $response = $this->client->applyDecisionToUser('some_user',
+            'user_looks_ok_payment_abuse',
+            'MANUAL_REVIEW',
+            array('analyst' => 'analyst@example.com')
+        );
         $this->assertTrue($response->isOk());
     }
 
@@ -396,13 +395,13 @@ class SiftClientTest extends PHPUnit_Framework_TestCase {
 
         SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
 
-        $response = $this->client->applyDecisionToOrder(array(
-          'user_id' => 'some_user',
-          'order_id' => 'ORDER_1234',
-          'decision_id' => 'order_looks_ok_payment_abuse',
-          'source' => 'MANUAL_REVIEW',
-          'analyst' => 'analyst@example.com',
-        ));
+        $response = $this->client->applyDecisionToOrder('some_user',
+            'ORDER_1234',
+            'order_looks_ok_payment_abuse',
+            'MANUAL_REVIEW',
+            array('analyst' => 'analyst@example.com')
+        );
+
         $this->assertTrue($response->isOk());
     }
 }


### PR DESCRIPTION
PR adds 3 methods to `SiftClient`

`getDecisions`
Allows folks to pull down a list of all their configured decisions.
[List Docs](https://siftscience.com/developers/docs/curl/decisions-api/decisions-list)

`applyDecisionToUser` & `applyDecisionToOrder`
Allows folks to apply decisions to entities.
[Apply Docs](https://siftscience.com/developers/docs/curl/decisions-api/apply-decisions)

@jburnim @garylee1 

Script:

```php
<?php
require __DIR__ . '/vendor/autoload.php';

$sift = new SiftClient(array(
    'api_key' => 'SOME_KEY',
    'account_id' => 'OUR_ID'
));

print 'fetching decisions configurations...' . "\n";

$response = $sift->getDecisions();

if ($response->isOk()) {
  foreach($response->body['data'] as $decision) {
    print $decision['id'] . ' : ' . $decision['entity_type'] . ' : ' . $decision['abuse_type'] . "\n";
  }
}

print 'applying user_decision decision to jalyn_fisher' . "\n";

$response = $sift->applyDecisionToUser('jalyn_fisher', 'user_decision', 'AUTOMATED_RULE');

if ($response->isOk()) {
  print 'successfully applied user_decision on jalyn_fisher' . "\n";
} else {
  print json_encode($response->body) . "\n";
  print 'Unable to apply decision on jalyn_fisher' . "\n";
}
```

Output:
```
sketchy_people : user : content_abuse
sup_legacy : user : legacy
sup_payment_abuse : user : payment_abuse
suspicious_hold_payment_abuse : user : payment_abuse
suspicious_user_account_abuse : user : account_abuse
test_decision2_legacy : user : legacy
testing : order : account_abuse
the_final_countdown__promotion_abuse : user : promotion_abuse
toshis_accept_decision_and_cb_payment_abuse : user : payment_abuse
transaction_with_filter_legacy : order : legacy
user_decision : user : payment_abuse
watch_legacy : user : legacy
watch_user_payment_abuse_payment_abuse : user : payment_abuse
applying user_decision decision to jalyn_fisher
successfully applied user_decision on jalyn_fisher
```