### PR TITLE
(For Mohammed) Add get session decisions api to PHP client helper

### DIFF
--- a/CHANGES.RST
+++ b/CHANGES.RST
@@ -1,7 +1,7 @@
 3.1.0 (2018-06-04)
 =================
 
-- Adds support for session decisions to [Decisions API](https://siftscience.com/developers/docs/curl/decisions-api)
+- Add support for get latest session decisions to [Decisions API](https://siftscience.com/developers/docs/curl/decisions-api)
 
 3.0.1 (2018-04-06)
 =================

--- a/CHANGES.RST
+++ b/CHANGES.RST
@@ -1,3 +1,8 @@
+3.1.0 (2018-06-04)
+=================
+
+- Adds support for session decisions to [Decisions API](https://siftscience.com/developers/docs/curl/decisions-api)
+
 3.0.1 (2018-04-06)
 =================
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ $response = $sift->getOrderDecisions('example_order');
 $response->body['decisions']['payment_abuse']['decision']['id']; // => "ship_order"
 ```
 
+### Get the latest decisions for a session
+```
+$sift = new SiftClient(array('api_key' => 'my_api_key', 'account_id' => 'my_account_id'));
+$response = $sift->getSessionDecisions('example_user', 'example_session');
+$response->body['decisions']['account_takeover']['decision']['id']; // => "session_decision"
+```
+
 ### List of configured Decisions
 **Optional Params**
  - `entity_type`: `user` or `order` or `session`

--- a/lib/Sift.php
+++ b/lib/Sift.php
@@ -12,7 +12,7 @@ abstract class Sift
 	 */
 	public static $account_id;
 
-	const VERSION = '3.0.1';
+	const VERSION = '3.1.0';
 
 	public static function setApiKey($api_key)
 	{

--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -336,6 +336,36 @@ class SiftClient {
         }
     }
 
+    /**
+     * Gets the latest decision for a session.
+     *
+     * @param string $user_id     The ID of session's user.
+     * @param string $session_id  The ID of a session.
+     *
+     * @param array $opts  Array of optional parameters for this request:
+     *     - string 'account_id': by default, this client's account ID is used.
+     *     - int 'timeout': By default, this client's timeout is used.
+     */
+    public function getSessionDecisions($user_id, $session_id, $opts = array()) {
+        $this->mergeArguments($opts, array(
+            'account_id' => $this->account_id,
+            'timeout' => $this->timeout
+        ));
+
+        $this->validateArgument($session_id, 'session id', 'string');
+
+        $url = (self::API3_ENDPOINT . '/v3/accounts/'
+                . $opts['account_id'] . '/users/' . $user_id . '/session/' . $session_id . '/decisions');
+
+        try {
+            $request = new SiftRequest($url, SiftRequest::GET, $opts['timeout'], self::API3_VERSION,
+                                       array('auth' => $this->api_key . ':'));
+            return $request->send();
+        } catch (Exception $e) {
+            $this->logError($e->getMessage());
+            return null;
+        }
+    }
 
     /**
      * Gets the latest decision for a piece of content.

--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -355,7 +355,7 @@ class SiftClient {
         $this->validateArgument($session_id, 'session id', 'string');
 
         $url = (self::API3_ENDPOINT . '/v3/accounts/'
-                . $opts['account_id'] . '/users/' . $user_id . '/session/' . $session_id . '/decisions');
+                . $opts['account_id'] . '/users/' . $user_id . '/sessions/' . $session_id . '/decisions');
 
         try {
             $request = new SiftRequest($url, SiftRequest::GET, $opts['timeout'], self::API3_VERSION,

--- a/test/SiftClientTest.php
+++ b/test/SiftClientTest.php
@@ -333,7 +333,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
 
 
     public function testGetSessionDecisions() {
-        $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/users/example_user/session/example_session/decisions';
+        $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/users/example_user/sessions/example_session/decisions';
         $mockResponse = new SiftResponse('{"decisions":{"account_takeover":{"decision":{"id":"session_decision"},"time":1468599638005,"webhook_succeeded":false},"time":1468517407135,"webhook_succeeded":true}}}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
 

--- a/test/SiftClientTest.php
+++ b/test/SiftClientTest.php
@@ -332,6 +332,15 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
 
+    public function testGetSessionDecisions() {
+        $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/users/example_user/session/example_session/decisions';
+        $mockResponse = new SiftResponse('{"decisions":{"account_takeover":{"decision":{"id":"session_decision"},"time":1468599638005,"webhook_succeeded":false},"time":1468517407135,"webhook_succeeded":true}}}', 200, null);
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
+
+        $response = $this->client->getSessionDecisions('example_user', 'example_session', array('timeout' => 4));
+        $this->assertTrue($response->isOk());
+    }
+
     public function testGetOrderDecisions() {
         $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/orders/example_order/decisions';
         $mockResponse = new SiftResponse('{"decisions":{"payment_abuse":{"decision":{"id":"order_decisionz"},"time":1468599638005,"webhook_succeeded":false},"account_abuse":{"decision":{"id":"good_order"},"time":1468517407135,"webhook_succeeded":true}}}', 200, null);


### PR DESCRIPTION
**Purpose:** 
- Adds support for get session level decisions.

**Technical overview:**
- Updates client methods to call new endpoint (https://siftscience.com/developers/docs/java/decisions-api/decision-status),

**Testing Plan**
- Expanded and added unit tests and run them locally.

**Deployment**
- Github release