### PR TITLE
(For David) Add support for rescore_user and get_user_score

### DIFF
--- a/CHANGES.RST
+++ b/CHANGES.RST
@@ -1,4 +1,11 @@
+3.3.0 (2018-08-02)
+=================
+
+- Add support for rescore_user and get_user_score APIs
+
 3.2.0 (2018-07-05)
+=================
+
 - Add new query parameter force_workflow_run
 
 3.1.0 (2018-06-04)

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["sift", "sift science", "php", "fraud"],
     "homepage": "https://github.com/SiftScience/sift-php",
     "license": "MIT",
-    "version": "3.0.1",
+    "version": "3.3.0",
     "authors": [
         {
             "name": "Alex Lopatin"
@@ -20,6 +20,9 @@
         },
         {
             "name": "Mohammed Jouahri"
+        },
+        {
+            "name": "Alex Paino"
         }
     ],
     "support": {

--- a/test/SiftClientTest.php
+++ b/test/SiftClientTest.php
@@ -200,6 +200,58 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
         $this->assertEquals($response->body['scores']['payment_abuse']['score'], 0.55);
     }
 
+    public function testSuccessfulGetUserScore() {
+        $mockUrl = 'https://api.siftscience.com/v205/users/12345/score?api_key=agreatsuccess';
+        $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
+            "user_id": "12345", "scores": {"payment_abuse": {score: 0.55}}}', 200, null);
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
+
+        $response = $this->client->get_user_score('12345');
+        $this->assertTrue($response->isOk());
+        $this->assertEquals($response->apiErrorMessage, 'OK');
+        $this->assertEquals($response->body['scores']['payment_abuse']['score'], 0.55);
+    }
+
+    public function testSuccessfulGetUserScoreWithAbuseTypes() {
+        $mockUrl = 'https://api.siftscience.com/v205/users/12345/score?api_key=agreatsuccess&abuse_types=payment_abuse%2Ccontent_abuse';
+        $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
+            "user_id": "12345", "scores": {"payment_abuse": {score: 0.55}}}', 200, null);
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
+
+        $response = $this->client->get_user_score('12345', array(
+            'abuse_types' => array('payment_abuse', 'content_abuse')
+        ));
+        $this->assertTrue($response->isOk());
+        $this->assertEquals($response->apiErrorMessage, 'OK');
+        $this->assertEquals($response->body['scores']['payment_abuse']['score'], 0.55);
+    }
+
+    public function testSuccessfulRescoreUser() {
+        $mockUrl = 'https://api.siftscience.com/v205/users/12345/score?api_key=agreatsuccess';
+        $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
+            "user_id": "12345", "scores": {"payment_abuse": {score: 0.55}}}', 200, null);
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
+
+        $response = $this->client->rescore_user('12345');
+        $this->assertTrue($response->isOk());
+        $this->assertEquals($response->apiErrorMessage, 'OK');
+        $this->assertEquals($response->body['scores']['payment_abuse']['score'], 0.55);
+    }
+
+    public function testSuccessfulRescoreUserWithAbuseTypes() {
+        $mockUrl = 'https://api.siftscience.com/v205/users/12345/score?api_key=agreatsuccess&abuse_types=payment_abuse%2Ccontent_abuse';
+        $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
+            "user_id": "12345", "scores": {"payment_abuse": {score: 0.55}}}', 200, null);
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
+
+        $response = $this->client->rescore_user('12345', array(
+            'abuse_types' => array('payment_abuse', 'content_abuse')
+        ));
+        $this->assertTrue($response->isOk());
+        $this->assertEquals($response->apiErrorMessage, 'OK');
+        $this->assertEquals($response->body['scores']['payment_abuse']['score'], 0.55);
+    }
+
     public function testSuccessfulSyncScoreFetch() {
         $mockUrl = 'https://api.siftscience.com/v205/events?return_score=true';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",


### PR DESCRIPTION
@ehrmann 

**Purpose**
Adds support for the new GET|Post /v205/users/{userId}/score APIs to this client library.

**Testing Plan**
1. Added new unit tests
2. Tested manually on the Sift test account.