### PR TITLE
URL Encoding

### DIFF
--- a/CHANGES.RST
+++ b/CHANGES.RST
@@ -1,3 +1,12 @@
+=======
+4.0.0 (2019-03-25)
+
+INCOMPATIBLE CHANGES INTRODUCED IN 4.0.0
+- Fix URL encoding
+  Previously, user id and session id encoding was either missing or handled forward slash
+  incorrectly. Callers with workarounds for this bug must remove these workarounds when upgrading
+  to 4.0.0.
+
 3.4.0 (2019-03-22)
 =================
 

--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -1,8 +1,7 @@
 <?php
 
 class SiftClient {
-    const API_ENDPOINT = 'https://api.siftscience.com';
-    const API3_ENDPOINT = 'https://api3.siftscience.com';
+    const API_ENDPOINT = 'https://api.sift.com';
 
     // Must be kept in sync with composer.json
     const API_VERSION = '205';
@@ -15,6 +14,7 @@ class SiftClient {
     private $account_id;
     private $timeout;
     private $version;
+    private $api_endpoint;
 
     /**
      * @var null|\Psr\Log\LoggerInterface
@@ -47,13 +47,16 @@ class SiftClient {
      *           Sift::$account_id.
      *     - int 'timeout': The number of seconds to wait before failing a request.  By default, 2.
      *     - string 'version': The version of Sift Science's API to call.  By default, '204'.
+     *     - string 'api_endpoint': The backend api to send requests to.  By default,
+     *           'https://api.sift.com'.
      */
     function  __construct($opts = array()) {
         $this->mergeArguments($opts, array(
             'api_key' => Sift::$api_key,
             'account_id' => Sift::$account_id,
             'timeout' => self::DEFAULT_TIMEOUT,
-            'version' => self::API_VERSION
+            'version' => self::API_VERSION,
+            'api_endpoint' => self::API_ENDPOINT,
         ));
 
         $this->validateArgument($opts['api_key'], 'api key', 'string');
@@ -62,6 +65,7 @@ class SiftClient {
         $this->account_id = $opts['account_id'];
         $this->timeout = $opts['timeout'];
         $this->version = $opts['version'];
+        $this->api_endpoint = $opts['api_endpoint'];
     }
 
 
@@ -347,7 +351,7 @@ class SiftClient {
 
         $this->validateArgument($run_id, 'run id', 'string');
 
-        $url = (self::API3_ENDPOINT .
+        $url = ($this->api_endpoint .
             '/v3/accounts/' . rawurlencode($opts['account_id']) .
             '/workflows/runs/' . rawurlencode($run_id));
 
@@ -379,7 +383,7 @@ class SiftClient {
 
         $this->validateArgument($user_id, 'user id', 'string');
 
-        $url = (self::API3_ENDPOINT .
+        $url = ($this->api_endpoint .
             '/v3/accounts/' . rawurlencode($opts['account_id']) .
             '/users/' . rawurlencode($user_id) .
             '/decisions');
@@ -412,7 +416,7 @@ class SiftClient {
 
         $this->validateArgument($order_id, 'order id', 'string');
 
-        $url = (self::API3_ENDPOINT .
+        $url = ($this->api_endpoint .
             '/v3/accounts/' . rawurlencode($opts['account_id']) .
             '/orders/' . rawurlencode($order_id) .
             '/decisions');
@@ -445,7 +449,7 @@ class SiftClient {
 
         $this->validateArgument($session_id, 'session id', 'string');
 
-        $url = (self::API3_ENDPOINT .
+        $url = ($this->api_endpoint .
             '/v3/accounts/' . rawurlencode($opts['account_id']) .
             '/users/' . rawurlencode($user_id) .
             '/sessions/' . rawurlencode($session_id) .
@@ -479,7 +483,7 @@ class SiftClient {
 
         $this->validateArgument($content_id, 'content id', 'string');
 
-        $url = (self::API3_ENDPOINT .
+        $url = ($this->api_endpoint .
             '/v3/accounts/' . rawurlencode($opts['account_id']) .
             '/users/' . rawurlencode($user_id) .
             '/content/' . rawurlencode($content_id) .
@@ -526,7 +530,7 @@ class SiftClient {
         if ($opts['next_ref']) {
             $url = $opts['next_ref'];
         } else {
-            $url = (self::API3_ENDPOINT .
+            $url = ($this->api_endpoint .
                 '/v3/accounts/' . rawurlencode($opts['account_id']) .
                 '/decisions');
 
@@ -579,7 +583,7 @@ class SiftClient {
 
         $this->validateArgument($user_id, 'user_id', 'string');
 
-        $url = (self::API3_ENDPOINT .
+        $url = ($this->api_endpoint .
             '/v3/accounts/' . rawurlencode($opts['account_id']) .
             '/users/'. rawurlencode($user_id) .
             '/decisions');
@@ -621,7 +625,7 @@ class SiftClient {
         $this->validateArgument($order_id, 'order_id', 'string');
         $this->validateArgument($user_id, 'user_id', 'string');
 
-        $url = (self::API3_ENDPOINT .
+        $url = ($this->api_endpoint .
             '/v3/accounts/' . rawurlencode($opts['account_id']) .
             '/users/' . rawurlencode($user_id) .
             '/orders/' . rawurlencode($order_id) .
@@ -664,7 +668,7 @@ class SiftClient {
 
         $this->validateArgument($content_id, 'content_id', 'string');
         $this->validateArgument($user_id, 'user_id', 'string');
-        $url = (self::API3_ENDPOINT .
+        $url = ($this->api_endpoint .
             '/v3/accounts/' . $opts['account_id'] .
             '/users/' . rawurlencode($user_id) .
             '/content/' . rawurlencode($content_id) .
@@ -707,7 +711,7 @@ class SiftClient {
         $this->validateArgument($session_id, 'session_id', 'string');
         $this->validateArgument($user_id, 'user_id', 'string');
 
-        $url = (self::API3_ENDPOINT .
+        $url = ($this->api_endpoint .
             '/v3/accounts/' . rawurlencode($opts['account_id']) .
             '/users/' . rawurlencode($user_id) .
             '/sessions/' . rawurlencode($session_id) .
@@ -785,23 +789,23 @@ class SiftClient {
             throw new InvalidArgumentException("${name} cannot be empty.");
     }
 
-    private static function restApiUrl($version) {
+    private function restApiUrl($version) {
         return self::urlPrefix($version) . '/events';
     }
 
-    private static function userLabelApiUrl($userId, $version) {
+    private function userLabelApiUrl($userId, $version) {
         return self::urlPrefix($version) . '/users/' . rawurlencode($userId) . '/labels';
     }
 
-    private static function scoreApiUrl($userId, $version) {
+    private function scoreApiUrl($userId, $version) {
         return self::urlPrefix($version) . '/score/' . rawurlencode($userId);
     }
 
-    private static function userScoreApiUrl($userId, $version) {
+    private function userScoreApiUrl($userId, $version) {
         return self::urlPrefix($version) . '/users/' . urlencode($userId) . '/score';
     }
 
-    private static function urlPrefix($version) {
-        return self::API_ENDPOINT . '/v' . $version;
+    private function urlPrefix($version) {
+        return $this->api_endpoint . '/v' . $version;
     }
 }

--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -347,8 +347,9 @@ class SiftClient {
 
         $this->validateArgument($run_id, 'run id', 'string');
 
-        $url = (self::API3_ENDPOINT . '/v3/accounts/'
-                . $opts['account_id'] . '/workflows/runs/' . $run_id);
+        $url = (self::API3_ENDPOINT .
+            '/v3/accounts/' . rawurlencode($opts['account_id']) .
+            '/workflows/runs/' . rawurlencode($run_id));
 
         try {
             $request = new SiftRequest($url, SiftRequest::GET, $opts['timeout'], self::API3_VERSION,
@@ -378,8 +379,10 @@ class SiftClient {
 
         $this->validateArgument($user_id, 'user id', 'string');
 
-        $url = (self::API3_ENDPOINT . '/v3/accounts/'
-                . $opts['account_id'] . '/users/' . $user_id . '/decisions');
+        $url = (self::API3_ENDPOINT .
+            '/v3/accounts/' . rawurlencode($opts['account_id']) .
+            '/users/' . rawurlencode($user_id) .
+            '/decisions');
 
         try {
             $request = new SiftRequest($url, SiftRequest::GET, $opts['timeout'], self::API3_VERSION,
@@ -409,8 +412,10 @@ class SiftClient {
 
         $this->validateArgument($order_id, 'order id', 'string');
 
-        $url = (self::API3_ENDPOINT . '/v3/accounts/'
-                . $opts['account_id'] . '/orders/' . $order_id . '/decisions');
+        $url = (self::API3_ENDPOINT .
+            '/v3/accounts/' . rawurlencode($opts['account_id']) .
+            '/orders/' . rawurlencode($order_id) .
+            '/decisions');
 
         try {
             $request = new SiftRequest($url, SiftRequest::GET, $opts['timeout'], self::API3_VERSION,
@@ -440,8 +445,11 @@ class SiftClient {
 
         $this->validateArgument($session_id, 'session id', 'string');
 
-        $url = (self::API3_ENDPOINT . '/v3/accounts/'
-                . $opts['account_id'] . '/users/' . $user_id . '/sessions/' . $session_id . '/decisions');
+        $url = (self::API3_ENDPOINT .
+            '/v3/accounts/' . rawurlencode($opts['account_id']) .
+            '/users/' . rawurlencode($user_id) .
+            '/sessions/' . rawurlencode($session_id) .
+            '/decisions');
 
         try {
             $request = new SiftRequest($url, SiftRequest::GET, $opts['timeout'], self::API3_VERSION,
@@ -471,8 +479,11 @@ class SiftClient {
 
         $this->validateArgument($content_id, 'content id', 'string');
 
-        $url = (self::API3_ENDPOINT . '/v3/accounts/'
-                . $opts['account_id'] . '/users/' . $user_id . '/content/' . $content_id . '/decisions');
+        $url = (self::API3_ENDPOINT .
+            '/v3/accounts/' . rawurlencode($opts['account_id']) .
+            '/users/' . rawurlencode($user_id) .
+            '/content/' . rawurlencode($content_id) .
+            '/decisions');
 
         try {
             $request = new SiftRequest($url, SiftRequest::GET, $opts['timeout'], self::API3_VERSION,
@@ -515,7 +526,9 @@ class SiftClient {
         if ($opts['next_ref']) {
             $url = $opts['next_ref'];
         } else {
-            $url = (self::API3_ENDPOINT . '/v3/accounts/' . $opts['account_id'] . '/decisions');
+            $url = (self::API3_ENDPOINT .
+                '/v3/accounts/' . rawurlencode($opts['account_id']) .
+                '/decisions');
 
             if ($opts['abuse_types']) $params['abuse_types'] = implode(',', $opts['abuse_types']);
             if ($opts['entity_type']) $params['entity_type'] = $opts['entity_type'];
@@ -567,8 +580,8 @@ class SiftClient {
         $this->validateArgument($user_id, 'user_id', 'string');
 
         $url = (self::API3_ENDPOINT .
-            '/v3/accounts/' . $opts['account_id'] .
-            '/users/'. $user_id .
+            '/v3/accounts/' . rawurlencode($opts['account_id']) .
+            '/users/'. rawurlencode($user_id) .
             '/decisions');
 
         return $this->applyDecision($url, $opts);
@@ -609,9 +622,9 @@ class SiftClient {
         $this->validateArgument($user_id, 'user_id', 'string');
 
         $url = (self::API3_ENDPOINT .
-            '/v3/accounts/' . $opts['account_id'] .
-            '/users/' . $user_id .
-            '/orders/' . $order_id .
+            '/v3/accounts/' . rawurlencode($opts['account_id']) .
+            '/users/' . rawurlencode($user_id) .
+            '/orders/' . rawurlencode($order_id) .
             '/decisions');
 
         return $this->applyDecision($url, $opts);
@@ -653,8 +666,8 @@ class SiftClient {
         $this->validateArgument($user_id, 'user_id', 'string');
         $url = (self::API3_ENDPOINT .
             '/v3/accounts/' . $opts['account_id'] .
-            '/users/' . $user_id .
-            '/content/' . $content_id .
+            '/users/' . rawurlencode($user_id) .
+            '/content/' . rawurlencode($content_id) .
             '/decisions');
 
         return $this->applyDecision($url, $opts);
@@ -695,9 +708,9 @@ class SiftClient {
         $this->validateArgument($user_id, 'user_id', 'string');
 
         $url = (self::API3_ENDPOINT .
-            '/v3/accounts/' . $opts['account_id'] .
-            '/users/' . $user_id .
-            '/sessions/' . $session_id .
+            '/v3/accounts/' . rawurlencode($opts['account_id']) .
+            '/users/' . rawurlencode($user_id) .
+            '/sessions/' . rawurlencode($session_id) .
             '/decisions');
 
         return $this->applyDecision($url, $opts);
@@ -777,11 +790,11 @@ class SiftClient {
     }
 
     private static function userLabelApiUrl($userId, $version) {
-        return self::urlPrefix($version) . '/users/' . urlencode($userId) . '/labels';
+        return self::urlPrefix($version) . '/users/' . rawurlencode($userId) . '/labels';
     }
 
     private static function scoreApiUrl($userId, $version) {
-        return self::urlPrefix($version) . '/score/' . urlencode($userId);
+        return self::urlPrefix($version) . '/score/' . rawurlencode($userId);
     }
 
     private static function userScoreApiUrl($userId, $version) {

--- a/test/SiftClient203Test.php
+++ b/test/SiftClient203Test.php
@@ -37,7 +37,7 @@ class SiftClient203Test extends PHPUnit\Framework\TestCase {
     }
 
     public function testSuccessfulTrackEvent() {
-        $mockUrl = 'https://api.siftscience.com/v203/events';
+        $mockUrl = 'https://api.sift.com/v203/events';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK"}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::POST ,$mockResponse);
         $response = $this->client->track('$transaction', $this->transaction_properties, array(
@@ -50,7 +50,7 @@ class SiftClient203Test extends PHPUnit\Framework\TestCase {
     public function testSuccessfulScoreFetch() {
         $this->client = new SiftClient(array(
             'api_key' => SiftClient203Test::$API_KEY, 'version' => '203'));
-        $mockUrl = 'https://api.siftscience.com/v203/score/12345?api_key=agreatsuccess';
+        $mockUrl = 'https://api.sift.com/v203/score/12345?api_key=agreatsuccess';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
                 "user_id": "12345", "score": 0.55}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
@@ -61,7 +61,7 @@ class SiftClient203Test extends PHPUnit\Framework\TestCase {
     }
 
     public function testSuccessfulSyncScoreFetch() {
-        $mockUrl = 'https://api.siftscience.com/v203/events?return_score=true';
+        $mockUrl = 'https://api.sift.com/v203/events?return_score=true';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
                 "score_response": {"user_id": "12345", "score": 0.55}}', 200, null);
 
@@ -79,7 +79,7 @@ class SiftClient203Test extends PHPUnit\Framework\TestCase {
     public function testSuccessfulLabelUser() {
         $this->client = new SiftClient(array(
             'api_key' => SiftClient203Test::$API_KEY, 'version' => '203'));
-        $mockUrl = 'https://api.siftscience.com/v203/users/54321/labels';
+        $mockUrl = 'https://api.sift.com/v203/users/54321/labels';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK"}', 200, null);
 
         SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
@@ -89,7 +89,7 @@ class SiftClient203Test extends PHPUnit\Framework\TestCase {
     }
 
     public function testSuccessfulUnlabelUser() {
-        $mockUrl = 'https://api.siftscience.com/v203/users/54321/labels?api_key=agreatsuccess';
+        $mockUrl = 'https://api.sift.com/v203/users/54321/labels?api_key=agreatsuccess';
         $mockResponse = new SiftResponse('', 204, null);
 
         SiftRequest::setMockResponse($mockUrl, SiftRequest::DELETE, $mockResponse);
@@ -101,7 +101,7 @@ class SiftClient203Test extends PHPUnit\Framework\TestCase {
     public function testSuccessfulScoreFetchWithAllUserIdCharacters() {
         $this->client = new SiftClient(array(
             'api_key' => SiftClient203Test::$API_KEY, 'version' => '203'));
-        $mockUrl = 'https://api.siftscience.com/v203/score/12345' . urlencode('=.-_+@:&^%!$') . '?api_key=agreatsuccess';
+        $mockUrl = 'https://api.sift.com/v203/score/12345' . urlencode('=.-_+@:&^%!$') . '?api_key=agreatsuccess';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
                 "user_id": "12345=.-_+@:&^%!$", "score": 0.55}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
@@ -113,7 +113,7 @@ class SiftClient203Test extends PHPUnit\Framework\TestCase {
 
     // Test all special characters for Label API
     public function testSuccessfulLabelWithAllUserIdCharacters() {
-        $mockUrl = 'https://api.siftscience.com/v203/users/54321' . urlencode('=.-_+@:&^%!$') . '/labels';
+        $mockUrl = 'https://api.sift.com/v203/users/54321' . urlencode('=.-_+@:&^%!$') . '/labels';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK"}', 200, null);
 
         SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
@@ -128,7 +128,7 @@ class SiftClient203Test extends PHPUnit\Framework\TestCase {
     public function testSuccessfulUnlabelWithAllUserIdCharacters() {
         $this->client = new SiftClient(array(
             'api_key' => SiftClient203Test::$API_KEY, 'version' => '203'));
-        $mockUrl = 'https://api.siftscience.com/v203/users/54321' . urlencode('=.-_+@:&^%!$') . '/labels?api_key=agreatsuccess';
+        $mockUrl = 'https://api.sift.com/v203/users/54321' . urlencode('=.-_+@:&^%!$') . '/labels?api_key=agreatsuccess';
         $mockResponse = new SiftResponse('', 204, null);
 
         SiftRequest::setMockResponse($mockUrl, SiftRequest::DELETE, $mockResponse);

--- a/test/SiftClientTest.php
+++ b/test/SiftClientTest.php
@@ -212,6 +212,15 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
         $this->assertEquals($response->body['scores']['payment_abuse']['score'], 0.55);
     }
 
+    public function testSuccessfulGetUserScoreWithSpecialCharacters() {
+        $mockUrl = 'https://api.sift.com/v205/users/em%2FDqw%3D%3D/score?api_key=agreatsuccess';
+        $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK"}', 200, null);
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
+
+        $response = $this->client->get_user_score('em/Dqw==');
+        $this->assertTrue($response->isOk());
+    }
+
     public function testSuccessfulGetUserScoreWithAbuseTypes() {
         $mockUrl = 'https://api.siftscience.com/v205/users/12345/score?api_key=agreatsuccess&abuse_types=payment_abuse%2Ccontent_abuse';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
@@ -365,6 +374,14 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
         $this->assertTrue($response->isOk());
     }
 
+    public function testGetWorkflowStatusWithSpecialCharacters() {
+        $mockUrl = 'https://api.sift.com/v3/accounts/5b2fd4ddbcf4254aa6baabb6/workflows/runs/1%2F2';
+        $mockResponse = new SiftResponse('{"id":"4zxwibludiaaa","config":{"id":"5rrbr4iaaa","version":"1468367620871"},"config_display_name":"workflow config","abuse_types":["payment_abuse"],"state":"running","entity":{"id":"example_user","type":"user"},"history":[{"app":"decision","name":"decision","state":"running","config":{"decision_id":"user_decision"}},{"app":"event","name":"Event","state":"finished","config":{}},{"app":"user","name":"Entity","state":"finished","config":{}}]}', 200, null);
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
+
+        $response = $this->client->getWorkflowStatus('1/2', array('account_id' => '5b2fd4ddbcf4254aa6baabb6'));
+        $this->assertTrue($response->isOk());
+    }
 
     public function testGetUserDecisions() {
         $mockUrl = 'https://api3.siftscience.com/v3/accounts/5b2fd4ddbcf4254aa6baabb6/users/example_user/decisions';
@@ -380,9 +397,19 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
 
     public function testGetUserDecisionsWithInvalidOption() {
         $this->expectException('InvalidArgumentException');
-        $response = $this->client->getUserDecisions('example_user', array('return_score' => true));
+        $this->client->getUserDecisions('example_user', array('return_score' => true));
     }
 
+    public function testGetUserDecisionsWithSpecialCharacters() {
+        $mockUrl = 'https://api.sift.com/v3/accounts/5b2fd4ddbcf4254aa6baabb6/users/em%2FDqw%3D%3D/decisions';
+        $mockResponse = new SiftResponse('{}', 200, null);
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
+
+        $this->client = new SiftClient(array(
+            'api_key' => SiftClientTest::$API_KEY, 'account_id' => '5b2fd4ddbcf4254aa6baabb6'));
+        $response = $this->client->getUserDecisions('em/Dqw==');
+        $this->assertTrue($response->isOk());
+    }
 
     public function testGetSessionDecisions() {
         $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/users/example_user/sessions/example_session/decisions';
@@ -393,12 +420,30 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
         $this->assertTrue($response->isOk());
     }
 
+    public function testGetSessionDecisionsWithSpecialCharacters() {
+        $mockUrl = 'https://api.sift.com/v3/accounts/90201c25e39320c45b3da37b/users/em%2FDqw%3D%3D/sessions/example_session/decisions';
+        $mockResponse = new SiftResponse('{}', 200, null);
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
+
+        $response = $this->client->getSessionDecisions('em/Dqw==', 'example_session', array('timeout' => 4));
+        $this->assertTrue($response->isOk());
+    }
+
     public function testGetOrderDecisions() {
         $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/orders/example_order/decisions';
         $mockResponse = new SiftResponse('{"decisions":{"payment_abuse":{"decision":{"id":"order_decisionz"},"time":1468599638005,"webhook_succeeded":false},"account_abuse":{"decision":{"id":"good_order"},"time":1468517407135,"webhook_succeeded":true}}}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
 
         $response = $this->client->getOrderDecisions('example_order', array('timeout' => 4));
+        $this->assertTrue($response->isOk());
+    }
+
+    public function testGetOrderDecisionsWithSpecialCharacters() {
+        $mockUrl = 'https://api.sift.com/v3/accounts/90201c25e39320c45b3da37b/orders/KyrVAPMJ%2Fyw%3D/decisions';
+        $mockResponse = new SiftResponse('{}', 200, null);
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
+
+        $response = $this->client->getOrderDecisions('KyrVAPMJ/yw=', array('timeout' => 4));
         $this->assertTrue($response->isOk());
     }
 
@@ -470,6 +515,20 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
         $this->assertTrue($response->isOk());
     }
 
+    public function testApplyDecisionToUserWithSpecialCharacters() {
+        $mockUrl = 'https://api.sift.com/v3/accounts/90201c25e39320c45b3da37b/users/em%2FDqw%3D%3D/decisions';
+        $mockResponse = new SiftResponse('{}', 200, null);
+
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
+
+        $response = $this->client->applyDecisionToUser('em/Dqw==',
+            'user_looks_ok_payment_abuse',
+            'MANUAL_REVIEW',
+            array('analyst' => 'analyst@example.com')
+        );
+        $this->assertTrue($response->isOk());
+    }
+
     public function testApplyDecisionToOrder() {
         $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/users/some_user/orders/ORDER_1234/decisions';
         $mockResponse = new SiftResponse('{' .
@@ -488,6 +547,22 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
 
         $response = $this->client->applyDecisionToOrder('some_user',
             'ORDER_1234',
+            'order_looks_ok_payment_abuse',
+            'MANUAL_REVIEW',
+            array('analyst' => 'analyst@example.com')
+        );
+
+        $this->assertTrue($response->isOk());
+    }
+
+    public function testApplyDecisionToOrderWithSpecialCharacters() {
+        $mockUrl = 'https://api.sift.com/v3/accounts/90201c25e39320c45b3da37b/users/em%2FDqw%3D%3D/orders/u2L8Qy%2B%2FAgM%3D/decisions';
+        $mockResponse = new SiftResponse('{}', 200, null);
+
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
+
+        $response = $this->client->applyDecisionToOrder('em/Dqw==',
+            'u2L8Qy+/AgM=',
             'order_looks_ok_payment_abuse',
             'MANUAL_REVIEW',
             array('analyst' => 'analyst@example.com')
@@ -522,6 +597,22 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
         $this->assertTrue($response->isOk());
     }
 
+    public function testApplyDecisionToSessionWithSpecialCharacters() {
+        $mockUrl = 'https://api.sift.com/v3/accounts/90201c25e39320c45b3da37b/users/em%2FDqw%3D%3D/sessions/u2L8Qy%2B%2FAgM%3D/decisions';
+        $mockResponse = new SiftResponse('{}', 200, null);
+
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
+
+        $response = $this->client->applyDecisionToSession('em/Dqw==',
+            'u2L8Qy+/AgM=',
+            'session_looks_ok_ato',
+            'MANUAL_REVIEW',
+            array('analyst' => 'analyst@example.com')
+        );
+
+        $this->assertTrue($response->isOk());
+    }
+
     public function testApplyDecisionToContent() {
         $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/users/some_user/content/CONTENT_12345/decisions';
         $mockResponse = new SiftResponse('{' .
@@ -540,6 +631,22 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
 
         $response = $this->client->applyDecisionToContent('some_user',
             'CONTENT_12345',
+            'content_looks_ok_content_abuse',
+            'MANUAL_REVIEW',
+            array('analyst' => 'analyst@example.com')
+        );
+
+        $this->assertTrue($response->isOk());
+    }
+
+    public function testApplyDecisionToContentWithSpecialCharacters() {
+        $mockUrl = 'https://api.sift.com/v3/accounts/90201c25e39320c45b3da37b/users/em%2FDqw%3D%3D/content/u2L8Qy%2B%2FAgM%3D/decisions';
+        $mockResponse = new SiftResponse('{}', 200, null);
+
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
+
+        $response = $this->client->applyDecisionToContent('em/Dqw==',
+            'u2L8Qy+/AgM=',
             'content_looks_ok_content_abuse',
             'MANUAL_REVIEW',
             array('analyst' => 'analyst@example.com')

--- a/test/SiftClientTest.php
+++ b/test/SiftClientTest.php
@@ -165,7 +165,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testSuccessfulTrackEvent() {
-        $mockUrl = 'https://api.siftscience.com/v205/events';
+        $mockUrl = 'https://api.sift.com/v205/events';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK"}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::POST ,$mockResponse);
 
@@ -175,7 +175,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testSuccessfulScoreFetch() {
-        $mockUrl = 'https://api.siftscience.com/v205/score/12345?api_key=agreatsuccess';
+        $mockUrl = 'https://api.sift.com/v205/score/12345?api_key=agreatsuccess';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
             "user_id": "12345", "scores": {"payment_abuse": {score: 0.55}}}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
@@ -187,7 +187,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testSuccessfulScoreFetchWithAbuseTypes() {
-        $mockUrl = 'https://api.siftscience.com/v205/score/12345?api_key=agreatsuccess&abuse_types=payment_abuse%2Ccontent_abuse';
+        $mockUrl = 'https://api.sift.com/v205/score/12345?api_key=agreatsuccess&abuse_types=payment_abuse%2Ccontent_abuse';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
             "user_id": "12345", "scores": {"payment_abuse": {score: 0.55}}}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
@@ -201,7 +201,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testSuccessfulGetUserScore() {
-        $mockUrl = 'https://api.siftscience.com/v205/users/12345/score?api_key=agreatsuccess';
+        $mockUrl = 'https://api.sift.com/v205/users/12345/score?api_key=agreatsuccess';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
             "user_id": "12345", "scores": {"payment_abuse": {score: 0.55}}}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
@@ -222,7 +222,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testSuccessfulGetUserScoreWithAbuseTypes() {
-        $mockUrl = 'https://api.siftscience.com/v205/users/12345/score?api_key=agreatsuccess&abuse_types=payment_abuse%2Ccontent_abuse';
+        $mockUrl = 'https://api.sift.com/v205/users/12345/score?api_key=agreatsuccess&abuse_types=payment_abuse%2Ccontent_abuse';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
             "user_id": "12345", "scores": {"payment_abuse": {score: 0.55}}}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
@@ -236,7 +236,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testSuccessfulRescoreUser() {
-        $mockUrl = 'https://api.siftscience.com/v205/users/12345/score?api_key=agreatsuccess';
+        $mockUrl = 'https://api.sift.com/v205/users/12345/score?api_key=agreatsuccess';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
             "user_id": "12345", "scores": {"payment_abuse": {score: 0.55}}}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
@@ -248,7 +248,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testSuccessfulRescoreUserWithAbuseTypes() {
-        $mockUrl = 'https://api.siftscience.com/v205/users/12345/score?api_key=agreatsuccess&abuse_types=payment_abuse%2Ccontent_abuse';
+        $mockUrl = 'https://api.sift.com/v205/users/12345/score?api_key=agreatsuccess&abuse_types=payment_abuse%2Ccontent_abuse';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
             "user_id": "12345", "scores": {"payment_abuse": {score: 0.55}}}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
@@ -262,7 +262,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testSuccessfulSyncScoreFetch() {
-        $mockUrl = 'https://api.siftscience.com/v205/events?return_score=true';
+        $mockUrl = 'https://api.sift.com/v205/events?return_score=true';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
             "score_response": {"user_id": "12345", "score": 0.55}}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
@@ -286,7 +286,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testSuccessfulSyncWorkflowStatusFetch() {
-        $mockUrl = 'https://api.siftscience.com/v205/events?return_workflow_status=true&abuse_types=legacy%2Caccount_abuse';
+        $mockUrl = 'https://api.sift.com/v205/events?return_workflow_status=true&abuse_types=legacy%2Caccount_abuse';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
             "score_response": {"user_id": "12345", "score": 0.55}}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
@@ -301,7 +301,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testSuccessfulLabelUser() {
-        $mockUrl = 'https://api.siftscience.com/v205/users/54321/labels';
+        $mockUrl = 'https://api.sift.com/v205/users/54321/labels';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK"}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
 
@@ -311,7 +311,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testSuccessfulUnlabelUser() {
-        $mockUrl = 'https://api.siftscience.com/v205/users/54321/labels?api_key=agreatsuccess';
+        $mockUrl = 'https://api.sift.com/v205/users/54321/labels?api_key=agreatsuccess';
         $mockResponse = new SiftResponse('', 204, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::DELETE, $mockResponse);
 
@@ -320,7 +320,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testSuccessfulUnlabelUserWithAbuseType() {
-        $mockUrl = 'https://api.siftscience.com/v205/users/54321/labels?api_key=agreatsuccess&abuse_type=account_abuse';
+        $mockUrl = 'https://api.sift.com/v205/users/54321/labels?api_key=agreatsuccess&abuse_type=account_abuse';
         $mockResponse = new SiftResponse('', 204, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::DELETE, $mockResponse);
 
@@ -330,7 +330,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
 
     // Test all special characters for score API
     public function testSuccessfulScoreFetchWithAllUserIdCharacters() {
-        $mockUrl = 'https://api.siftscience.com/v205/score/12345' . urlencode('=.-_+@:&^%!$') . '?api_key=agreatsuccess';
+        $mockUrl = 'https://api.sift.com/v205/score/12345' . urlencode('=.-_+@:&^%!$') . '?api_key=agreatsuccess';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK",
             "user_id": "12345=.-_+@:&^%!$", "score": 0.55}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
@@ -343,7 +343,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
 
     // Test all special characters for Label API
     public function testSuccessfulLabelWithAllUserIdCharacters() {
-        $mockUrl = 'https://api.siftscience.com/v205/users/54321' . urlencode('=.-_+@:&^%!$') . '/labels';
+        $mockUrl = 'https://api.sift.com/v205/users/54321' . urlencode('=.-_+@:&^%!$') . '/labels';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK"}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::POST, $mockResponse);
 
@@ -354,7 +354,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
 
     // Test all special characters for Unlabel API
     public function testSuccessfulUnlabelWithAllUserIdCharacters() {
-        $mockUrl = 'https://api.siftscience.com/v205/users/54321' . urlencode('=.-_+@:&^%!$') . '/labels?api_key=agreatsuccess';
+        $mockUrl = 'https://api.sift.com/v205/users/54321' . urlencode('=.-_+@:&^%!$') . '/labels?api_key=agreatsuccess';
         $mockResponse = new SiftResponse('', 204, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::DELETE, $mockResponse);
 
@@ -364,7 +364,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
 
 
     public function testGetWorkflowStatus() {
-        $mockUrl = 'https://api3.siftscience.com/v3/accounts/5b2fd4ddbcf4254aa6baabb6/workflows/runs/a8r89d6yh3hkn';
+        $mockUrl = 'https://api.sift.com/v3/accounts/5b2fd4ddbcf4254aa6baabb6/workflows/runs/a8r89d6yh3hkn';
         $mockResponse = new SiftResponse('{"id":"4zxwibludiaaa","config":{"id":"5rrbr4iaaa","version":"1468367620871"},"config_display_name":"workflow config","abuse_types":["payment_abuse"],"state":"running","entity":{"id":"example_user","type":"user"},"history":[{"app":"decision","name":"decision","state":"running","config":{"decision_id":"user_decision"}},{"app":"event","name":"Event","state":"finished","config":{}},{"app":"user","name":"Entity","state":"finished","config":{}}]}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
 
@@ -384,7 +384,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testGetUserDecisions() {
-        $mockUrl = 'https://api3.siftscience.com/v3/accounts/5b2fd4ddbcf4254aa6baabb6/users/example_user/decisions';
+        $mockUrl = 'https://api.sift.com/v3/accounts/5b2fd4ddbcf4254aa6baabb6/users/example_user/decisions';
         $mockResponse = new SiftResponse('{"decisions":{"payment_abuse":{"decision":{"id":"user_decision"},"time":1468707128659,"webhook_succeeded":false}}}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
 
@@ -412,7 +412,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testGetSessionDecisions() {
-        $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/users/example_user/sessions/example_session/decisions';
+        $mockUrl = 'https://api.sift.com/v3/accounts/90201c25e39320c45b3da37b/users/example_user/sessions/example_session/decisions';
         $mockResponse = new SiftResponse('{"decisions":{"account_takeover":{"decision":{"id":"session_decision"},"time":1468599638005,"webhook_succeeded":false},"time":1468517407135,"webhook_succeeded":true}}}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
 
@@ -430,7 +430,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testGetOrderDecisions() {
-        $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/orders/example_order/decisions';
+        $mockUrl = 'https://api.sift.com/v3/accounts/90201c25e39320c45b3da37b/orders/example_order/decisions';
         $mockResponse = new SiftResponse('{"decisions":{"payment_abuse":{"decision":{"id":"order_decisionz"},"time":1468599638005,"webhook_succeeded":false},"account_abuse":{"decision":{"id":"good_order"},"time":1468517407135,"webhook_succeeded":true}}}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::GET, $mockResponse);
 
@@ -448,7 +448,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testGetDecisionList() {
-        $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/decisions';
+        $mockUrl = 'https://api.sift.com/v3/accounts/90201c25e39320c45b3da37b/decisions';
         $mockResponse = new SiftResponse('{"data": [{' .
           '"id": "block_user_payment_abuse", "name": "Block user",' .
           '"description": "cancel and refund all of the user\'s' .
@@ -469,7 +469,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testGetDecisionListNextRef() {
-        $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/decisions?from=10&limit=5';
+        $mockUrl = 'https://api.sift.com/v3/accounts/90201c25e39320c45b3da37b/decisions?from=10&limit=5';
         $mockResponse = new SiftResponse('{"data": [{' .
           '"id": "block_user_payment_abuse", "name": "Block user",' .
           '"description": "cancel and refund all of the user\'s' .
@@ -492,7 +492,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testApplyDecisionToUser() {
-        $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/users/some_user/decisions';
+        $mockUrl = 'https://api.sift.com/v3/accounts/90201c25e39320c45b3da37b/users/some_user/decisions';
         $mockResponse = new SiftResponse('{' .
             '"entity": {' .
             '"id" : "some_user"' .
@@ -530,7 +530,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testApplyDecisionToOrder() {
-        $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/users/some_user/orders/ORDER_1234/decisions';
+        $mockUrl = 'https://api.sift.com/v3/accounts/90201c25e39320c45b3da37b/users/some_user/orders/ORDER_1234/decisions';
         $mockResponse = new SiftResponse('{' .
             '"entity": {' .
             '"id" : "ORDER_1234"' .
@@ -572,7 +572,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testApplyDecisionToSession() {
-        $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/users/some_user/sessions/SESSION_12345/decisions';
+        $mockUrl = 'https://api.sift.com/v3/accounts/90201c25e39320c45b3da37b/users/some_user/sessions/SESSION_12345/decisions';
         $mockResponse = new SiftResponse('{' .
             '"entity": {' .
             '"id" : "SESSION_12345"' .
@@ -614,7 +614,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testApplyDecisionToContent() {
-        $mockUrl = 'https://api3.siftscience.com/v3/accounts/90201c25e39320c45b3da37b/users/some_user/content/CONTENT_12345/decisions';
+        $mockUrl = 'https://api.sift.com/v3/accounts/90201c25e39320c45b3da37b/users/some_user/content/CONTENT_12345/decisions';
         $mockResponse = new SiftResponse('{' .
             '"entity": {' .
             '"id" : "CONTENT_12345"' .
@@ -656,7 +656,7 @@ class SiftClientTest extends PHPUnit\Framework\TestCase {
     }
 
     public function testTrackProfileEvent() {
-        $mockUrl = 'https://api.siftscience.com/v205/events';
+        $mockUrl = 'https://api.sift.com/v205/events';
         $mockResponse = new SiftResponse('{"status": 0, "error_message": "OK"}', 200, null);
         SiftRequest::setMockResponse($mockUrl, SiftRequest::POST ,$mockResponse);
 


### PR DESCRIPTION
Fix URL encoding issues.

Currently, `score` requests use `urlencode` for path params, and `decisions` requests don't encode path params. `urlencode` [doesn't encode forward slashes](https://www.php.net/manual/en/function.urlencode.php) and encodes spaces and pluses (`+`), causing decoding errors for some user_ids (`user+123@example.com`, `ZtzSkoQE/7nvaO479TIQww==`). `rawurlencode` [is compatible with path components](https://www.php.net/manual/en/function.rawurlencode.php), so use it instead.

Currently, for `/v3` endpoints, if there's a literal forward slash in a username, the backend returns a 404. If the slash is encoded, it works:
```
curl -u ${$API_KEY}: "https://api.sift.com/v3/accounts/$ACCOUNT_ID/users/foo/bar/decisions"
{"error":"not_found","description":"The requested resource does not exist"}

curl -u ${$API_KEY}: "https://api.sift.com/v3/accounts/$ACCOUNT_ID/users/foo%2fbar/decisions"
{"decisions":{}}
```

For the `/v2xx/score` endpoint, if there's a literal slash in the username, the first segment is considered the username, the second is discarded:
```
curl "https://api.sift.com/v205/score/foo/bar?api_key=$API_KEY"
{ "status" : 54 , "error_message" : "Specified user_id has no scorable events" , "user_id" : "foo"}
```

If the username is encoded, a 400 is returned with a misleading error message:
```
curl "https://api.sift.com/v205/score/foo%2fbar?api_key=$API_KEY"
{"status": 59, "error_message": "Invalid URI; the user_id portion of the URI must be URI encoded", "time": 1553553712}
```

The user_id validation difference between `/v2xx` and `/v3` is a known issue. This change doesn't address it, but it passes correctly encoded ids so we can have consistent user id handling.