### PR TITLE
Add curl error code and message to SiftResponse

### DIFF
--- a/CHANGES.RST
+++ b/CHANGES.RST
@@ -3,6 +3,7 @@
 
 - Add hooks for changing api endpoint and passing custom curl_opts
 - Fix autoloading errors when PEAR packages are not present
+- Add curl and /v3 error codes and messages to SiftResponse
 
 INCOMPATIBLE CHANGES INTRODUCED IN 4.0.0
 - Fix URL encoding

--- a/CHANGES.RST
+++ b/CHANGES.RST
@@ -1,4 +1,4 @@
-4.0.0 (2019-03-28)
+4.0.0 (2019-04-01)
 =======
 
 - Add hooks for changing api endpoint and passing custom curl_opts

--- a/lib/SiftRequest.php
+++ b/lib/SiftRequest.php
@@ -111,11 +111,11 @@ class SiftRequest {
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         $result = curl_exec($ch);
         $httpStatusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-
-        // Close the curl connection
+        $curlErrno = curl_errno($ch);
+        $curlError = curl_error($ch);
         curl_close($ch);
 
-        return new SiftResponse($result, $httpStatusCode, $this);
+        return new SiftResponse($result, $httpStatusCode, $this, $curlErrno, $curlError);
     }
 
     public static function setMockResponse($url, $method, $response) {


### PR DESCRIPTION
Add `curlErrno`, `curlError`, `apiError`, and `apiDescription` to `SiftResponse` and set them when there's a curl error or `/v3` error.