### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -114,7 +114,7 @@ class SiftClient {
             'return_workflow_status' => false,
             'force_workflow_run' => false,
             'abuse_types' => array(),
-            'path' => NULL,
+            'path' => null,
             'timeout' => $this->timeout,
             'version' => $this->version
         ));


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!