### PR TITLE
Adding the logic to tag slack users upon build failures.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,46 @@
-version: 2
+version: 2.1
+
+orbs:
+  slack: circleci/slack@4.1
+
+slack/notify: &slack_notify
+  branch_pattern: master
+  event: fail
+  channel: ci-build-status
+  template: SLACK_TAG_CI_FAILURE_TEMPLATE
+
+commands:
+  export_slack_id:
+    steps:
+      - run:
+          name  : Exporting circleci username as slack id.
+          command: echo 'export SLACK_PARAM_MENTIONS="$CIRCLE_USERNAME"' >> "$BASH_ENV"
+      - run:
+          name : CircleCi To Slack user mapping.
+          command: |
+            echo $GITHUB_SLACK_USERMAPPING | base64 --decode > github_slack
+            while read -r line || [[ -n $line ]];
+            do
+              [[ ${line//[[:space:]]/} =~ ^#.* || -z "$line" ]] && continue
+              echo "$line" | tr "=" "\n" | while read -r key; do
+              read -r value
+              if [ "$CIRCLE_USERNAME" = "${key}" ]; then
+                echo "export SLACK_PARAM_MENTIONS='<@${value}>'" >> $BASH_ENV
+              fi
+              done
+            done < github_slack
+            rm github_slack
+
+context: &context
+  - slack-templates
+  - slack_Oauth
+  - Github_Slack_UserMapping
 
 "-": &build7
   working_directory: ~/sift-php
   steps:
     - checkout
+    - export_slack_id
     - run: sudo composer self-update
     - restore_cache:
         keys:
@@ -15,6 +52,8 @@ version: 2
         paths:
           - vendor
     - run: composer exec phpunit -v -- --bootstrap vendor/autoload.php test
+    - slack/notify:
+        <<: *slack_notify
 
 jobs:
   build71:
@@ -34,6 +73,9 @@ workflows:
   version: 2
   check_compile:
     jobs:
-      - build71
-      - build72
-      - build73
+      - build71:
+          context: *context
+      - build72:
+          context: *context
+      - build73:
+          context: *context


### PR DESCRIPTION
## Purpose:
- Tagging users in slack upon build failures.

## Technical overview:
- Adding the logic to tag the users on slack upon build failures.
- export_slack_id command reads the GITHUB_SLACK_USERMAPPING which is the encoding of dictionary containing circleci to slack user mapping and tags the users accordingly.
- Adding the context and slack notification commands. 

## Testing plan:
- Tested it on the custom branch on the code repo and was getting tagged for build failures.
![Screen Shot 2022-11-08 at 2 55 56 PM](https://user-images.githubusercontent.com/13412061/200695533-416c764e-1189-42f8-9299-a31e248d8386.png)

## Deployment plan:
- Merge the code to master and we can test the failure.

## Rollback plan:
- Revert the PR. 

## Customer Impact Assessment:
- Internal Users.
