### PR TITLE
Fixed tests not running when PR was created outside the org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,12 @@ context: &context
         paths:
           - vendor
     - run: composer exec phpunit -v -- --bootstrap vendor/autoload.php test
-    - slack/notify:
-        <<: *slack_notify
+    - when:
+        condition:
+          equal: [ master, << pipeline.git.branch >> ]
+        steps:
+          - slack/notify:
+              <<: *slack_notify
 
 jobs:
   build71:


### PR DESCRIPTION
We have PRs that contractors made:
* https://github.com/SiftScience/sift-php/pull/90
* https://github.com/SiftScience/sift-php/pull/91

Since they are not members of our organization, the context used by the slack notification step was not available and all jobs were failing. This PR will change the behavior of the slack notification, so that it won't run on any branches but `master`.