### PR TITLE
API-7682: Add support for warnings in Events API

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,19 @@ $sift = new SiftClient();
 ## Usage
 
 ### Track an event
-Here's an example that sends a `$transaction` event to sift.
+To learn more about the Events API visit our [developer docs](https://developers.sift.com/docs/php/events-api/overview).
+
+**Optional Params**
+- `return_score`: `:true` or `:false`
+- `return_action`: `:true` or `:false`
+- `return_workflow_status`: `:true` or `:false`
+- `return_route_info`: `:true` or `:false`
+- `force_workflow_run`: `:true` or `:false`
+- `include_score_percentiles`: `:true` or `:false`
+- `warnings`: `:true` or `:false`
+- `abuse_types`: `["payment_abuse", "content_abuse", "content_abuse", "account_abuse", "legacy", "account_takeover"]`
+
+Here's an example that sends a `$transaction` event to Sift.
 ```php
 $sift = new SiftClient(['api_key' => 'my_api_key', 'account_id' => 'my_account_id']);
 $response = $sift->track('$transaction', [

--- a/lib/SiftClient.php
+++ b/lib/SiftClient.php
@@ -105,7 +105,9 @@ class SiftClient {
      *           version of the Events API is used.
      *     - include_score_percentiles(optional) : Whether to add new parameter in the query parameter.
      *     - if include_score_percentiles is true then add a new parameter called fields in the query parameter
-     * 
+     *     - include_warnings(optional) : Whether to add list of warnings (if any) to response.
+     *     - if include_warnings is true then add 'warnings' to the 'fields' query parameter.
+     *
      * @return null|SiftResponse
      */
     public function track($event, $properties, $opts = []) {
@@ -119,7 +121,8 @@ class SiftClient {
             'path' => null,
             'timeout' => $this->timeout,
             'version' => $this->version,
-            'include_score_percentiles' => false
+            'include_score_percentiles' => false,
+            'include_warnings' => false
         ]);
 
         $this->validateArgument($event, 'event', 'string');
@@ -146,8 +149,16 @@ class SiftClient {
             $params['force_workflow_run'] = 'true';
         if ($opts['abuse_types'])
             $params['abuse_types'] = implode(',', $opts['abuse_types']);
-        if($opts['include_score_percentiles'])
-            $params['fields'] = 'SCORE_PERCENTILES';
+        if ($opts['include_score_percentiles'] || $opts['include_warnings']) {
+            $fields = [];
+            if ($opts['include_score_percentiles']) {
+                $fields[] = 'SCORE_PERCENTILES';
+            }
+            if ($opts['include_warnings']) {
+                $fields[] = 'WARNINGS';
+            }
+            $params['fields'] = implode(',', $fields);
+        }
             
         try {
             $request = new SiftRequest(

--- a/test/SiftClientTest.php
+++ b/test/SiftClientTest.php
@@ -1417,6 +1417,31 @@ class SiftClientTest extends TestCase
         );
     }
 
+    public function testSuccessfulTrackEventWithWarnings(): void {
+        $mockUrl = 'https://api.sift.com/v205/events?fields=WARNINGS';
+        $mockResponse = new SiftResponse('
+        {
+            "status": 0, "error_message": "OK",
+            "warnings": {
+                "count": 1,
+                "items": [
+                    {
+                        "message": "Invalid field value"
+                    }
+                ]
+            }
+        }', 200, null);
+        SiftRequest::setMockResponse($mockUrl, SiftRequest::POST ,$mockResponse);
+        $response = $this->client->track('$transaction', $this->transaction_properties, [
+            "version" => "205", "include_warnings" => true
+        ]);
+
+        $this->assertTrue($response->isOk());
+        $this->assertEquals('OK', $response->apiErrorMessage);
+        $this->assertEquals(1, $response->body["warnings"]["count"]);
+        $this->assertEquals('Invalid field value', $response->body["warnings"]["items"][0]["message"]);
+    }
+
     public function testPostWebhook(): void
     {
         $mockUrl =

--- a/test_integration_app/events_api/test_events_api.php
+++ b/test_integration_app/events_api/test_events_api.php
@@ -1400,10 +1400,30 @@
                 '$verified_event'     => '$login',
                 '$reason'             => '$automated_rule', // Verification was triggered based on risk score
                 '$verification_type'  => '$sms',
-                '$verified_value'     => '14155551212'
+                '$verified_value'     => '14155551212',
+                '$verified_entity_id' => $GLOBALS['session_id']
             );
     
             return $this->client->track('$verification', $properties);
+        }
+
+        function verification_with_warnings()
+        {
+            // Sample $verification event
+            $properties = array(
+                // Required Fields
+                '$user_id'            => $GLOBALS['user_id'],
+                '$session_id'         => $GLOBALS['session_id'],
+                '$status'             => '$pending',
+
+                // $verified_entity_id is not provided to generate warnings
+                '$verified_event'     => '$login',
+                '$reason'             => '$automated_rule',
+                '$verification_type'  => '$sms',
+                '$verified_value'     => '14155551212'
+            );
+
+            return $this->client->track('$verification', $properties, ["include_warnings" => true]);
         }
 
     }

--- a/test_integration_app/main.php
+++ b/test_integration_app/main.php
@@ -50,6 +50,7 @@
             $this->assertEquals(1, $objUtil->isOk($objEvents->update_order()));
             $this->assertEquals(1, $objUtil->isOk($objEvents->update_password()));
             $this->assertEquals(1, $objUtil->isOk($objEvents->verification()));
+            $this->assertEquals(1, $objUtil->hasWarnings($objEvents->verification_with_warnings()));
             print("Events API Tested \n");
 
             // Decisions API
@@ -112,6 +113,16 @@
             else{
                 return false;
             }
+        }
+
+        public function hasWarnings($response) {
+            // expect http status 200, api status 0, and warnings present
+            if (isset($response->apiStatus)){
+                return ($response->apiStatus == 0)
+                    && (200 === $response->httpStatusCode)
+                    && ($response->body["warnings"]);
+            }
+            return false;
         }
     }
 


### PR DESCRIPTION
## Purpose
https://sift.atlassian.net/browse/API-7682

## Summary
- if `include_warnings` is true then add `warnings` to the `fields` query parameter.

## Testing
- Added unit test
- Added integration test

## Checklist
- [x] The change was thoroughly tested manually
- [x] The change was covered with unit tests
- [x] The change was tested with real API calls (if applicable)
- [x] Necessary changes were made in the integration tests (if applicable)
- [x] New functionality is reflected in README
